### PR TITLE
block: pull-quote

### DIFF
--- a/blocks/pull-quote/pull-quote.css
+++ b/blocks/pull-quote/pull-quote.css
@@ -1,0 +1,20 @@
+main .pull-quote {
+    border-left: 3px solid #367ea8;
+    padding: 12px 24px;
+    margin: 64px 0;
+}
+main .pull-quote p {
+    margin: .5em 0;
+}
+main .pull-quote img {
+    height: 96px;
+    width: 96px;
+    object-fit: cover;
+    border-radius: 100%;
+    margin: 0;
+}
+main .pull-quote h2,
+main .pull-quote h3 {
+    margin-top: 32px;
+    color: #367ea8;
+}

--- a/blocks/pull-quote/pull-quote.css
+++ b/blocks/pull-quote/pull-quote.css
@@ -18,8 +18,10 @@ main .pull-quote img {
     border-radius: 100%;
     margin: 0;
 }
-main .pull-quote h2,
-main .pull-quote h3 {
-    margin-top: 32px;
+main .pull-quote blockquote {
+    margin: 32px 0 0 0;
     color: var(--color-quote);
+    font-weight: var(--heading-font-weight);
+    line-height: var(--heading-line-height);
+    font-size: var(--heading-font-size-l);
 }

--- a/blocks/pull-quote/pull-quote.css
+++ b/blocks/pull-quote/pull-quote.css
@@ -1,5 +1,10 @@
+/* variables for pull-quote block */
 main .pull-quote {
-    border-left: 3px solid #367ea8;
+    --color-quote: #367ea8;
+}
+/**/
+main .pull-quote {
+    border-left: 3px solid var(--color-quote);
     padding: 12px 24px;
     margin: 64px 0;
 }
@@ -16,5 +21,5 @@ main .pull-quote img {
 main .pull-quote h2,
 main .pull-quote h3 {
     margin-top: 32px;
-    color: #367ea8;
+    color: var(--color-quote);
 }

--- a/blocks/pull-quote/pull-quote.js
+++ b/blocks/pull-quote/pull-quote.js
@@ -2,7 +2,7 @@ export default function decorate($block) {
     $block.querySelectorAll('p').forEach(($p) => {       
         // Quote <p> to <h2>
         if ($p.innerHTML.startsWith('“') && $p.innerHTML.endsWith('”')) {
-            replaceElementType($p, 'h2');
+            replaceElementType($p, 'blockquote');
         }
     });
 }

--- a/blocks/pull-quote/pull-quote.js
+++ b/blocks/pull-quote/pull-quote.js
@@ -1,0 +1,25 @@
+export default function decorate($block) {
+    $block.querySelectorAll('p').forEach(($p) => {       
+        // Quote <p> to <h2>
+        if ($p.innerHTML.startsWith('“') && $p.innerHTML.endsWith('”')) {
+            replaceElementType($p, 'h2');
+        }
+    });
+}
+
+/**
+ * This is a helper function that could be reusable for other blocks.
+ * @param {Element} $e The original element that subject to replace.
+ * @param {string} type The nodeName to be set for $e.
+ * @returns $n Updated Element
+ */
+export const replaceElementType = ($e, type) => {
+    // If they are same, no need to replace.
+    if ($e.nodeName === type.toUpperCase()) {
+        return $e;
+    }
+    const $n = document.createElement(type);
+    $n.innerHTML = $e.innerHTML;
+    $e.parentNode.replaceChild($n, $e);
+    return $n;
+}


### PR DESCRIPTION
## Description

This will do for Pull quote block.
For QA:
https://block-pull-quote--business-website--adobe.hlx3.page/drafts/uncled/blog/kitchen-sink#pull-quote-block



## Related Issue
https://github.com/adobe/business-website/issues/5

## Motivation and Context
This is requested by David Nuescheler.

## How Has This Been Tested?
There is no test plan added for this block.
I would add test case that \<p\> with quote replaces with \<h2\>

## Screenshots (if appropriate):
The styles are not exactly same as blog.adobe.com's example, because some of styles should be applied more in higher level than block. (like font-famaily). I believe this should good enough for now.

End result:
![image](https://user-images.githubusercontent.com/55804872/126557905-0cad6f30-a34b-48d8-bffd-df099266b376.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
