### PR TITLE
Block images initial setup and styling

### DIFF
--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,0 +1,5 @@
+.legend {
+    font-style: italic;
+    font-size: 14px;
+    color: #4b4b4b;
+}

--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,5 +1,21 @@
-.legend {
+/* caption styling */
+main .images .legend {
+    text-align: left;
     font-style: italic;
-    font-size: 14px;
-    color: #4b4b4b;
+    font-size: var(--body-font-size-s);
+    color: var(--color-gray-700);
+}
+
+main .images .figure {
+    text-align: center;
+}
+
+main .images-list {
+    display: flex;
+}
+
+@media (max-width: 900px) {
+    main .images-list {
+        flex-direction: column;
+    }
 }

--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -8,14 +8,36 @@ main .images .legend {
 
 main .images .figure {
     text-align: center;
+    margin: 0;
+    padding: 0.5em 0;
 }
 
 main .images-list {
+    margin: 64px 0;
     display: flex;
+}
+
+main .images-list-2 > :first-child {
+    /* border: 2px solid red; */
+    margin-right: 32px;
+}
+
+main .images-list-3 > :nth-child(2) {
+    margin-left: 32px;
+    margin-right: 32px;
 }
 
 @media (max-width: 900px) {
     main .images-list {
         flex-direction: column;
+    }
+
+    main .images-list-2 > :first-child {
+        margin-right: 0;
+    }
+
+    main .images-list-3 > :nth-child(2) {
+        margin-left: 0;
+        margin-right: 0;
     }
 }

--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,24 +1,45 @@
 /* caption styling */
 main .images .legend {
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
     text-align: left;
     font-style: italic;
     font-size: var(--body-font-size-s);
     color: var(--color-gray-700);
 }
 
-main .images .figure {
+main .images {
+    margin-left: 0;
+    margin-right: 0;
+    max-width: 800px;
     text-align: center;
-    margin: 0;
-    padding: 0.5em 0;
+}
+
+main .images .figure {
+    margin: 1.5em auto 0.5em;
+}
+
+main .images .images-list .figure {
+    margin-top: 0.5em;
+}
+
+main .images .figure img {
+    margin-top: 64px;
+    max-width: 100%;
+    max-height: 600px;
+    width: unset;
+}
+
+main .images .images-list .figure img {
+    margin-top: 0;
 }
 
 main .images-list {
-    margin: 64px 0;
     display: flex;
+    margin: 64px 0;
 }
 
 main .images-list-2 > :first-child {
-    /* border: 2px solid red; */
     margin-right: 32px;
 }
 

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -10,7 +10,6 @@ export default function decorateImages(blockEl) {
 }
 
 function buildColumns(rowEl, count) {
-  console.log(count);
   const columnEls = Array.from(rowEl.children);
   columnEls.forEach((columnEl) => {
     const figEl = buildFigure(columnEl);

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,6 +1,7 @@
 export default function decorateImages(blockEl) {
-  if (blockEl.firstChild.childElementCount > 1) {
-    const rowEl = buildColumns(blockEl.firstChild);
+  const blockCount = blockEl.firstChild.childElementCount;
+  if (blockCount > 1) {
+    buildColumns(blockEl.firstChild, blockCount);
   } else {
     const figEl = buildFigure(blockEl.firstChild.firstChild);
     blockEl.innerHTML = '';
@@ -8,16 +9,15 @@ export default function decorateImages(blockEl) {
   }
 }
 
-function buildColumns(rowEl) {
+function buildColumns(rowEl, count) {
+  console.log(count);
   const columnEls = Array.from(rowEl.children);
   columnEls.forEach((columnEl) => {
     const figEl = buildFigure(columnEl);
     columnEl.remove();
     rowEl.append(figEl);
   })
-  // prep for flex
-  rowEl.classList.add("images-list");
-  return rowEl;
+  rowEl.classList.add("images-list", `images-list-${count}`);
 }
 
 function buildFigure(blockEl) {
@@ -42,6 +42,7 @@ function buildFigure(blockEl) {
   return figEl;
 }
 
+// TODO: move out for use throughout
 function buildCaption(pEl) {
   const figCaptionEl = document.createElement('figcaption');
   figCaptionEl.classList.add('caption');

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,32 +1,61 @@
 export default function decorateImages(blockEl) {
-    // places pictures in figures
-    const parentEl = blockEl.firstChild.firstChild;    
-    const figEl = document.createElement('figure');
-    // TODO: support multi-column images blocks
-    blockEl.querySelectorAll('p').forEach((pEl) => {
-      if (pEl.innerHTML.startsWith('<picture>')) {
-        const pictureEl = pEl.querySelector('picture');
-        figEl.append(pictureEl);
-        pEl.remove();
-      } else if (pEl.innerHTML.startsWith('<em>')) {
-        // TODO: remove caption from this block for use in other blocks
-        // create caption
-        const figCaptionEl = document.createElement('figcaption');
-        figCaptionEl.classList.add('caption');  
-        pEl.classList.add('legend');
-        // add text to caption
-        figCaptionEl.append(pEl);
-        figEl.append(figCaptionEl);
-      } else if (pEl.innerHTML.startsWith('<a')) {
-        // wrap picture in anchor
-        const aEl = pEl.querySelector('a');
-        const figPicEl = figEl.querySelector('picture');
-        aEl.innerHTML = '';
-        aEl.append(figPicEl);
-        figEl.prepend(aEl);
-        pEl.remove();
-      }
-    });
-    parentEl.prepend(figEl);
+  if (blockEl.firstChild.childElementCount > 1) {
+    const rowEl = buildColumns(blockEl.firstChild);
+  } else {
+    const figEl = buildFigure(blockEl.firstChild.firstChild);
+    blockEl.innerHTML = '';
+    blockEl.append(figEl);
   }
-  
+}
+
+function buildColumns(rowEl) {
+  const columnEls = Array.from(rowEl.children);
+  columnEls.forEach((columnEl) => {
+    const figEl = buildFigure(columnEl);
+    columnEl.remove();
+    rowEl.append(figEl);
+  })
+  // prep for flex
+  rowEl.classList.add("images-list");
+  return rowEl;
+}
+
+function buildFigure(blockEl) {
+  let figEl = document.createElement('figure');
+  figEl.classList.add("figure");
+  // content is picture only, no caption or link
+  if (blockEl.firstChild.nodeName === "PICTURE") {
+    figEl.append(blockEl.firstChild);
+  } else if (blockEl.firstChild.nodeName === "P") {
+    const pEls = Array.from(blockEl.children);
+    pEls.forEach((pEl) => {
+      if (pEl.firstChild.nodeName === "PICTURE") {
+        figEl.append(pEl.firstChild);
+      } else if (pEl.firstChild.nodeName === "EM") {
+        const figCapEl = buildCaption(pEl);
+        figEl.append(figCapEl);
+      } else if (pEl.firstChild.nodeName === "A") {
+        figEl = wrapPicInAnchor(figEl, pEl.firstChild);
+      }
+    })
+  }
+  return figEl;
+}
+
+function buildCaption(pEl) {
+  const figCaptionEl = document.createElement('figcaption');
+  figCaptionEl.classList.add('caption');
+  pEl.classList.add('legend');
+  figCaptionEl.append(pEl);
+  return figCaptionEl;  
+}
+
+function wrapPicInAnchor(figEl, aEl) {
+  const picEl = figEl.querySelector('picture');
+  if (picEl) {
+    aEl.textContent = '';
+    aEl.append(picEl);
+    figEl.prepend(aEl);
+  }
+  return figEl;
+}

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,0 +1,32 @@
+export default function decorateImages(blockEl) {
+    // places pictures in figures
+    const parentEl = blockEl.firstChild.firstChild;    
+    const figEl = document.createElement('figure');
+    // TODO: support multi-column images blocks
+    blockEl.querySelectorAll('p').forEach((pEl) => {
+      if (pEl.innerHTML.startsWith('<picture>')) {
+        const pictureEl = pEl.querySelector('picture');
+        figEl.append(pictureEl);
+        pEl.remove();
+      } else if (pEl.innerHTML.startsWith('<em>')) {
+        // TODO: remove caption from this block for use in other blocks
+        // create caption
+        const figCaptionEl = document.createElement('figcaption');
+        figCaptionEl.classList.add('caption');  
+        pEl.classList.add('legend');
+        // add text to caption
+        figCaptionEl.append(pEl);
+        figEl.append(figCaptionEl);
+      } else if (pEl.innerHTML.startsWith('<a')) {
+        // wrap picture in anchor
+        const aEl = pEl.querySelector('a');
+        const figPicEl = figEl.querySelector('picture');
+        aEl.innerHTML = '';
+        aEl.append(figPicEl);
+        figEl.prepend(aEl);
+        pEl.remove();
+      }
+    });
+    parentEl.prepend(figEl);
+  }
+  


### PR DESCRIPTION
## Description

- `picture` tags in images block are placed in `figure` tags
- if images block has a caption (italic text in block), caption is placed in `figcaption`
- if images block has a link, `picture` is wrapped in `a`

## Related Issue

#6 

## Motivation and Context

semantically link images to captions, mimic blog initial styling

## Screenshots (if appropriate):

images block with caption and link
<img width="1050" alt="images block with caption and link screenshot" src="https://user-images.githubusercontent.com/43383503/126831668-29fb4fa6-3592-4f34-a81b-f7293d46998d.png">

images block with side-by-side images with captions (2- and 3-column supported)
<img width="1049" alt="images block with side-by-side images with captions" src="https://user-images.githubusercontent.com/43383503/126831823-7a166b56-db0e-4ae6-b02d-027c1ffcdbc5.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
