### PR TITLE
feat(hero): build and style hero img

### DIFF
--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,13 +1,3 @@
-/* caption styling */
-main .images .legend {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    text-align: left;
-    font-style: italic;
-    font-size: var(--body-font-size-s);
-    color: var(--color-gray-700);
-}
-
 main .images {
     margin-left: 0;
     margin-right: 0;

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -19,7 +19,12 @@ function buildColumns(rowEl, count) {
   rowEl.classList.add("images-list", `images-list-${count}`);
 }
 
-function buildFigure(blockEl) {
+/**
+ * This is a helper function that could be reusable for other blocks.
+ * @param {Element} blockEl The original element to be placed in figure.
+ * @returns figEl Generated figure
+ */
+export function buildFigure(blockEl) {
   let figEl = document.createElement('figure');
   figEl.classList.add("figure");
   // content is picture only, no caption or link

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,15 +1,5 @@
 import { buildFigure } from '../../scripts/scripts.js';
 
-export function wrapPicInAnchor(figEl, aEl) {
-  const picEl = figEl.querySelector('picture');
-  if (picEl) {
-    aEl.textContent = '';
-    aEl.append(picEl);
-    figEl.prepend(aEl);
-  }
-  return figEl;
-}
-
 function buildColumns(rowEl, count) {
   const columnEls = Array.from(rowEl.children);
   columnEls.forEach((columnEl) => {

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,44 +1,11 @@
+import { buildFigure } from '../../scripts/scripts.js';
+
 export function wrapPicInAnchor(figEl, aEl) {
   const picEl = figEl.querySelector('picture');
   if (picEl) {
     aEl.textContent = '';
     aEl.append(picEl);
     figEl.prepend(aEl);
-  }
-  return figEl;
-}
-
-// TODO: move out for use throughout
-export function buildCaption(pEl) {
-  const figCaptionEl = document.createElement('figcaption');
-  pEl.classList.add('caption');
-  figCaptionEl.append(pEl);
-  return figCaptionEl;
-}
-
-/**
- * This is a helper function that could be reusable for other blocks.
- * @param {Element} blockEl The original element to be placed in figure.
- * @returns figEl Generated figure
- */
-export function buildFigure(blockEl) {
-  let figEl = document.createElement('figure');
-  figEl.classList.add('figure');
-  // content is picture only, no caption or link
-  if (blockEl.firstChild.nodeName === 'PICTURE') {
-    figEl.append(blockEl.firstChild);
-  } else if (blockEl.firstChild.nodeName === 'P') {
-    const pEls = Array.from(blockEl.children);
-    pEls.forEach((pEl) => {
-      if (pEl.firstChild.nodeName === 'PICTURE') {
-        figEl.append(pEl.firstChild);
-      } else if (pEl.firstChild.nodeName === 'EM') {
-        const figCapEl = buildCaption(pEl);
-        figEl.append(figCapEl);
-      } else if (pEl.firstChild.nodeName === 'A') {
-        figEl = wrapPicInAnchor(figEl, pEl.firstChild);
-      }
-    });
   }
   return figEl;
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 /* global sessionStorage, Image */
-import { wrapPicInAnchor } from '../blocks/images/images.js';
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file
@@ -178,7 +177,12 @@ export function buildFigure(blockEl) {
         const figCapEl = buildCaption(pEl);
         figEl.append(figCapEl);
       } else if (pEl.firstChild.nodeName === 'A') {
-        figEl = wrapPicInAnchor(figEl, pEl.firstChild);
+        const picEl = figEl.querySelector('picture');
+        if (picEl) {
+          pEl.firstChild.textContent = '';
+          pEl.firstChild.append(picEl);
+          figEl.prepend(pEl.firstChild);
+        }
       }
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  */
 /* global sessionStorage, Image */
+import {
+  buildFigure
+} from '/blocks/images/images.js';
 
 /**
  * Loads a CSS file.
@@ -103,6 +106,36 @@ function decorateBlocks($main) {
   $main
     .querySelectorAll('div.section-wrapper > div > div')
     .forEach(($block) => decorateBlock($block));
+}
+
+/**
+ * Decorates hero image.
+ */
+function decorateHero() {
+  const h1El = document.querySelector('main h1');
+  // create container to pass to buildFigure func
+  const containerEl = document.createElement('div'); 
+  if (h1El) {
+    // check for hero image
+    let hasHero = h1El.parentElement.querySelector('p picture') || false;
+    if (hasHero) {
+      const heroEl = hasHero.parentNode;
+      // check for hero caption
+      const heroPicSiblingEl = heroEl.nextElementSibling;
+      const heroPicCaption = heroPicSiblingEl || false;
+      // populate container to pass to buildFigure func
+      if (heroEl) { containerEl.append(heroEl) };
+      if (heroPicCaption) { containerEl.append(heroPicCaption) };
+      const figContainerEl = document.createElement('div');
+      figContainerEl.classList.add('hero-image');
+      const figEl = buildFigure(containerEl);
+      figEl.classList.add('hero-image-figure');
+      figContainerEl.append(figEl);
+      h1El.parentNode.parentNode.parentNode.append(figContainerEl);
+      // insert hero div below H1 parent
+      h1El.parentNode.parentNode.parentNode.insertBefore(figContainerEl, h1El.parentNode.parentNode.nextSibling);
+    }
+  }
 }
 
 /**
@@ -292,6 +325,7 @@ export function decorateMain($main) {
   checkWebpFeature(() => {
     webpPolyfill($main);
   });
+  decorateHero();
   decorateBlocks($main);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -10,10 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /* global sessionStorage, Image */
-import {
-  buildFigure
-} from '/blocks/images/images.js';
-
+import { wrapPicInAnchor } from '../blocks/images/images.js';
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file
@@ -150,31 +147,72 @@ function buildAutoBlocks(mainEl) {
 }
 
 /**
- * Decorates hero image.
+ * Build figcaption element
+ * @param {Element} pEl The original element to be placed in figcaption.
+ * @returns figCaptionEl Generated figcaption
  */
-function decorateHero() {
-  const h1El = document.querySelector('main h1');
+export function buildCaption(pEl) {
+  const figCaptionEl = document.createElement('figcaption');
+  pEl.classList.add('caption');
+  figCaptionEl.append(pEl);
+  return figCaptionEl;
+}
+
+/**
+ * Build figure element
+ * @param {Element} blockEl The original element to be placed in figure.
+ * @returns figEl Generated figure
+ */
+export function buildFigure(blockEl) {
+  let figEl = document.createElement('figure');
+  figEl.classList.add('figure');
+  // content is picture only, no caption or link
+  if (blockEl.firstChild.nodeName === 'PICTURE') {
+    figEl.append(blockEl.firstChild);
+  } else if (blockEl.firstChild.nodeName === 'P') {
+    const pEls = Array.from(blockEl.children);
+    pEls.forEach((pEl) => {
+      if (pEl.firstChild.nodeName === 'PICTURE') {
+        figEl.append(pEl.firstChild);
+      } else if (pEl.firstChild.nodeName === 'EM') {
+        const figCapEl = buildCaption(pEl);
+        figEl.append(figCapEl);
+      } else if (pEl.firstChild.nodeName === 'A') {
+        figEl = wrapPicInAnchor(figEl, pEl.firstChild);
+      }
+    });
+  }
+  return figEl;
+}
+
+/**
+ * Decorates feature image.
+ */
+function decorateFeatureImg() {
+  const h1 = document.querySelector('main h1');
   // create container to pass to buildFigure func
-  const containerEl = document.createElement('div'); 
-  if (h1El) {
-    // check for hero image
-    let hasHero = h1El.parentElement.querySelector('p picture') || false;
-    if (hasHero) {
-      const heroEl = hasHero.parentNode;
+  const containerEl = document.createElement('div');
+  if (h1) {
+    // check for feature image
+    const hasFeatureImg = h1.parentElement.querySelector('p picture') || false;
+    if (hasFeatureImg) {
+      const featureImgEl = hasFeatureImg.parentNode;
       // check for hero caption
-      const heroPicSiblingEl = heroEl.nextElementSibling;
-      const heroPicCaption = heroPicSiblingEl || false;
+      const featureImgSiblingEl = featureImgEl.nextElementSibling;
+      const featureImgCaption = featureImgSiblingEl || false;
       // populate container to pass to buildFigure func
-      if (heroEl) { containerEl.append(heroEl) };
-      if (heroPicCaption) { containerEl.append(heroPicCaption) };
+      if (featureImgEl) { containerEl.append(featureImgEl); }
+      if (featureImgCaption) { containerEl.append(featureImgCaption); }
       const figContainerEl = document.createElement('div');
-      figContainerEl.classList.add('hero-image');
+      figContainerEl.classList.add('feature-image');
       const figEl = buildFigure(containerEl);
-      figEl.classList.add('hero-image-figure');
+      figEl.classList.add('feature-image-figure');
       figContainerEl.append(figEl);
-      h1El.parentNode.parentNode.parentNode.append(figContainerEl);
-      // insert hero div below H1 parent
-      h1El.parentNode.parentNode.parentNode.insertBefore(figContainerEl, h1El.parentNode.parentNode.nextSibling);
+      h1.parentNode.parentNode.parentNode.append(figContainerEl);
+      // insert feature img div below H1 parent
+      h1.parentNode.parentNode.parentNode.insertBefore(
+        figContainerEl, h1.parentNode.parentNode.nextSibling,
+      );
     }
   }
 }
@@ -366,11 +404,8 @@ export function decorateMain($main) {
   checkWebpFeature(() => {
     webpPolyfill($main);
   });
-<<<<<<< HEAD
-  decorateHero();
-=======
+  decorateFeatureImg();
   buildAutoBlocks($main);
->>>>>>> main
   decorateBlocks($main);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -292,7 +292,6 @@ header {
   background-color: #FFF;
 }
 
-<<<<<<< HEAD
 /* hero */
 
 main .hero-image {
@@ -327,19 +326,11 @@ main .hero-image .hero-image-figure .caption {
 }
 
 /* caption styling */
-main .legend {
-=======
-/* caption styling */
 main .caption {
->>>>>>> main
   margin-top: 1.5em;
   margin-bottom: 0.5em;
   text-align: left;
   font-style: italic;
   font-size: var(--body-font-size-s);
   color: var(--color-gray-700);
-<<<<<<< HEAD
-}
-=======
 } 
->>>>>>> main

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -315,7 +315,6 @@ main .hero-image .hero-image-figure .caption {
   padding: 0 32px;
   max-width: 830px;
   margin: auto;
-  /* border: 2px solid red; */
 }
 
 @media (max-width: 900px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -292,33 +292,33 @@ header {
   background-color: #FFF;
 }
 
-/* hero */
+/* feature img */
 
-main .hero-image {
+main .feature-image {
   width: 100%;
   padding: 0;
   margin: auto;
   max-width: 1000px;
 }
 
-main .hero-image .hero-image-figure {
+main .feature-image .feature-image-figure {
   margin: 0;
 }
 
-main .hero-image .hero-image-figure img {
+main .feature-image .feature-image-figure img {
   width: 100%;
   max-height: 438px;
   object-fit: cover;
 }
 
-main .hero-image .hero-image-figure .caption {
+main .feature-image .feature-image-figure .caption {
   padding: 0 32px;
   max-width: 830px;
   margin: auto;
 }
 
 @media (max-width: 900px) {
-  main .hero-image .hero-image-figure .caption {
+  main .feature-image .feature-image-figure .caption {
     margin: auto;
     max-width: 375px;
     padding: 0 32px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -292,3 +292,46 @@ header {
   background-color: #FFF;
 }
 
+/* hero */
+
+main .hero-image {
+  width: 100%;
+  padding: 0;
+  margin: auto;
+  max-width: 1000px;
+}
+
+main .hero-image .hero-image-figure {
+  margin: 0;
+}
+
+main .hero-image .hero-image-figure img {
+  width: 100%;
+  max-height: 438px;
+  object-fit: cover;
+}
+
+main .hero-image .hero-image-figure .caption {
+  padding: 0 32px;
+  max-width: 830px;
+  margin: auto;
+  /* border: 2px solid red; */
+}
+
+@media (max-width: 900px) {
+  main .hero-image .hero-image-figure .caption {
+    margin: auto;
+    max-width: 375px;
+    padding: 0 32px;
+  }
+}
+
+/* caption styling */
+main .legend {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  text-align: left;
+  font-style: italic;
+  font-size: var(--body-font-size-s);
+  color: var(--color-gray-700);
+}


### PR DESCRIPTION
## Description

- export `buildFigure` function
- globalize `.caption` styles
- build hero block > place hero image in `figure` (add caption if applicable) > place hero block after `h1` container

## Related Issue

#13 

## Motivation and Context

build structure for hero images, mimic blog style

## Screenshots (if appropriate):

hero image with caption (no caption also supported)
<img width="1019" alt="hero image with caption" src="https://user-images.githubusercontent.com/43383503/126851499-aa7d8226-1631-4e49-8987-df0f3204a38c.png">
** note: definitely not correct spacing between `h1` and hero block, styling `h1` outside the scope of this PR

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
