### PR TITLE
feat: prep inline images for image block styling

### DIFF
--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,7 +1,6 @@
 main .images {
     margin-left: 0;
     margin-right: 0;
-    max-width: 800px;
     text-align: center;
 }
 

--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -1,13 +1,3 @@
-/* caption styling */
-main .images .legend {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    text-align: left;
-    font-style: italic;
-    font-size: var(--body-font-size-s);
-    color: var(--color-gray-700);
-}
-
 main .images {
     margin-left: 0;
     margin-right: 0;

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -1,22 +1,19 @@
-export default function decorateImages(blockEl) {
-  const blockCount = blockEl.firstChild.childElementCount;
-  if (blockCount > 1) {
-    buildColumns(blockEl.firstChild, blockCount);
-  } else {
-    const figEl = buildFigure(blockEl.firstChild.firstChild);
-    blockEl.innerHTML = '';
-    blockEl.append(figEl);
+export function wrapPicInAnchor(figEl, aEl) {
+  const picEl = figEl.querySelector('picture');
+  if (picEl) {
+    aEl.textContent = '';
+    aEl.append(picEl);
+    figEl.prepend(aEl);
   }
+  return figEl;
 }
 
-function buildColumns(rowEl, count) {
-  const columnEls = Array.from(rowEl.children);
-  columnEls.forEach((columnEl) => {
-    const figEl = buildFigure(columnEl);
-    columnEl.remove();
-    rowEl.append(figEl);
-  })
-  rowEl.classList.add('images-list', `images-list-${count}`);
+// TODO: move out for use throughout
+export function buildCaption(pEl) {
+  const figCaptionEl = document.createElement('figcaption');
+  pEl.classList.add('caption');
+  figCaptionEl.append(pEl);
+  return figCaptionEl;
 }
 
 /**
@@ -24,7 +21,7 @@ function buildColumns(rowEl, count) {
  * @param {Element} blockEl The original element to be placed in figure.
  * @returns figEl Generated figure
  */
- export function buildFigure(blockEl) {
+export function buildFigure(blockEl) {
   let figEl = document.createElement('figure');
   figEl.classList.add('figure');
   // content is picture only, no caption or link
@@ -41,25 +38,28 @@ function buildColumns(rowEl, count) {
       } else if (pEl.firstChild.nodeName === 'A') {
         figEl = wrapPicInAnchor(figEl, pEl.firstChild);
       }
-    })
+    });
   }
   return figEl;
 }
 
-// TODO: move out for use throughout
-export function buildCaption(pEl) {
-  const figCaptionEl = document.createElement('figcaption');
-  pEl.classList.add('caption');
-  figCaptionEl.append(pEl);
-  return figCaptionEl;  
+function buildColumns(rowEl, count) {
+  const columnEls = Array.from(rowEl.children);
+  columnEls.forEach((columnEl) => {
+    const figEl = buildFigure(columnEl);
+    columnEl.remove();
+    rowEl.append(figEl);
+  });
+  rowEl.classList.add('images-list', `images-list-${count}`);
 }
 
-export function wrapPicInAnchor(figEl, aEl) {
-  const picEl = figEl.querySelector('picture');
-  if (picEl) {
-    aEl.textContent = '';
-    aEl.append(picEl);
-    figEl.prepend(aEl);
+export default function decorateImages(blockEl) {
+  const blockCount = blockEl.firstChild.childElementCount;
+  if (blockCount > 1) {
+    buildColumns(blockEl.firstChild, blockCount);
+  } else {
+    const figEl = buildFigure(blockEl.firstChild.firstChild);
+    blockEl.innerHTML = '';
+    blockEl.append(figEl);
   }
-  return figEl;
 }

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -16,7 +16,7 @@ function buildColumns(rowEl, count) {
     columnEl.remove();
     rowEl.append(figEl);
   })
-  rowEl.classList.add("images-list", `images-list-${count}`);
+  rowEl.classList.add('images-list', `images-list-${count}`);
 }
 
 /**
@@ -26,19 +26,19 @@ function buildColumns(rowEl, count) {
  */
  export function buildFigure(blockEl) {
   let figEl = document.createElement('figure');
-  figEl.classList.add("figure");
+  figEl.classList.add('figure');
   // content is picture only, no caption or link
-  if (blockEl.firstChild.nodeName === "PICTURE") {
+  if (blockEl.firstChild.nodeName === 'PICTURE') {
     figEl.append(blockEl.firstChild);
-  } else if (blockEl.firstChild.nodeName === "P") {
+  } else if (blockEl.firstChild.nodeName === 'P') {
     const pEls = Array.from(blockEl.children);
     pEls.forEach((pEl) => {
-      if (pEl.firstChild.nodeName === "PICTURE") {
+      if (pEl.firstChild.nodeName === 'PICTURE') {
         figEl.append(pEl.firstChild);
-      } else if (pEl.firstChild.nodeName === "EM") {
+      } else if (pEl.firstChild.nodeName === 'EM') {
         const figCapEl = buildCaption(pEl);
         figEl.append(figCapEl);
-      } else if (pEl.firstChild.nodeName === "A") {
+      } else if (pEl.firstChild.nodeName === 'A') {
         figEl = wrapPicInAnchor(figEl, pEl.firstChild);
       }
     })
@@ -47,15 +47,14 @@ function buildColumns(rowEl, count) {
 }
 
 // TODO: move out for use throughout
-function buildCaption(pEl) {
+export function buildCaption(pEl) {
   const figCaptionEl = document.createElement('figcaption');
-  figCaptionEl.classList.add('caption');
-  pEl.classList.add('legend');
+  pEl.classList.add('caption');
   figCaptionEl.append(pEl);
   return figCaptionEl;  
 }
 
-function wrapPicInAnchor(figEl, aEl) {
+export function wrapPicInAnchor(figEl, aEl) {
   const picEl = figEl.querySelector('picture');
   if (picEl) {
     aEl.textContent = '';

--- a/blocks/images/images.js
+++ b/blocks/images/images.js
@@ -19,7 +19,12 @@ function buildColumns(rowEl, count) {
   rowEl.classList.add("images-list", `images-list-${count}`);
 }
 
-function buildFigure(blockEl) {
+/**
+ * This is a helper function that could be reusable for other blocks.
+ * @param {Element} blockEl The original element to be placed in figure.
+ * @returns figEl Generated figure
+ */
+ export function buildFigure(blockEl) {
   let figEl = document.createElement('figure');
   figEl.classList.add("figure");
   // content is picture only, no caption or link

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -67,7 +67,7 @@ export function toClassName(name) {
 /**
  * Wraps each section in an additional {@code div}.
  * @param {[Element]} $sections The sections
- */ 
+ */
 function wrapSections($sections) {
   $sections.forEach(($div) => {
     if (!$div.id) {
@@ -101,12 +101,12 @@ export function decorateBlock($block) {
  */
 function buildImageBlocks(mainEl) {
   // remove styling from images, if any
-  const styledImgEls = [ ...mainEl.querySelectorAll('strong picture'), ...mainEl.querySelectorAll('em picture')];
+  const styledImgEls = [...mainEl.querySelectorAll('strong picture'), ...mainEl.querySelectorAll('em picture')];
   styledImgEls.forEach((imgEl) => {
     const parentEl = imgEl.closest('p');
     parentEl.prepend(imgEl);
     parentEl.lastChild.remove();
-  })
+  });
   // select all non-featured, default (non-images block) images
   const imgEls = Array.from(mainEl.querySelectorAll('div.section-wrapper:not(:first-of-type) > div > p > picture'));
   imgEls.forEach((imgEl) => {
@@ -124,12 +124,12 @@ function buildImageBlocks(mainEl) {
     const secondNestEl = document.createElement('div');
     // populate images block
     firstNestEl.append(parentEl.cloneNode(true));
-    if (imgCaptionEl) { firstNestEl.append(imgCaptionEl) };
+    if (imgCaptionEl) { firstNestEl.append(imgCaptionEl); }
     secondNestEl.append(firstNestEl);
     blockEl.append(secondNestEl);
     parentEl.parentNode.insertBefore(blockEl, parentEl);
     parentEl.remove();
-  })
+  });
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,10 @@
  */
 /* global sessionStorage, Image */
 
+import {
+  buildFigure
+} from '/blocks/images/images.js';
+
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file
@@ -67,7 +71,7 @@ export function toClassName(name) {
 /**
  * Wraps each section in an additional {@code div}.
  * @param {[Element]} $sections The sections
- */
+ */ 
 function wrapSections($sections) {
   $sections.forEach(($div) => {
     if (!$div.id) {
@@ -93,6 +97,44 @@ export function decorateBlock($block) {
   }
   $block.classList.add('block');
   $block.setAttribute('data-block-name', blockName);
+}
+
+/**
+ * Decorates all inline images in a container element.
+ * @param {Element} mainEl The container element
+ */
+function decorateImages(mainEl) {
+  // remove styling from images, if any
+  const styledImgEls = [ ...mainEl.querySelectorAll('strong picture'), ...mainEl.querySelectorAll('em picture')];
+  styledImgEls.forEach((imgEl) => {
+    const parentEl = imgEl.closest('p');
+    parentEl.prepend(imgEl);
+    parentEl.lastChild.remove();
+  })
+  // select all non-hero, non-image-block images
+  const imgEls = Array.from(mainEl.querySelectorAll('div.section-wrapper:not(:first-of-type) > div > p > picture'));
+  imgEls.forEach((imgEl) => {
+    const parentEl = imgEl.parentNode;
+    const parentSiblingEl = parentEl.nextElementSibling;
+    let imgCaptionEl;
+    // check for caption immediately following image
+    if (parentSiblingEl.firstChild.nodeName === 'EM') {
+      imgCaptionEl = parentSiblingEl;
+    }
+    const blockEl = document.createElement('div');
+    // build image block nested div structure
+    blockEl.classList.add('images', 'block');
+    blockEl.setAttribute('data-block-name', 'images');
+    const firstNestEl = document.createElement('div');
+    const secondNestEl = document.createElement('div');
+    // populate images block
+    firstNestEl.append(parentEl.cloneNode(true));
+    if (imgCaptionEl) { firstNestEl.append(imgCaptionEl) };
+    secondNestEl.append(firstNestEl);
+    blockEl.append(secondNestEl);
+    parentEl.parentNode.insertBefore(blockEl, parentEl);
+    parentEl.remove();
+  })
 }
 
 /**
@@ -292,6 +334,7 @@ export function decorateMain($main) {
   checkWebpFeature(() => {
     webpPolyfill($main);
   });
+  decorateImages($main);
   decorateBlocks($main);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,10 +11,6 @@
  */
 /* global sessionStorage, Image */
 
-import {
-  buildFigure
-} from '/blocks/images/images.js';
-
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file
@@ -100,10 +96,10 @@ export function decorateBlock($block) {
 }
 
 /**
- * Decorates all inline images in a container element.
+ * Decorates all default images in a container element.
  * @param {Element} mainEl The container element
  */
-function decorateImages(mainEl) {
+function buildImageBlocks(mainEl) {
   // remove styling from images, if any
   const styledImgEls = [ ...mainEl.querySelectorAll('strong picture'), ...mainEl.querySelectorAll('em picture')];
   styledImgEls.forEach((imgEl) => {
@@ -111,7 +107,7 @@ function decorateImages(mainEl) {
     parentEl.prepend(imgEl);
     parentEl.lastChild.remove();
   })
-  // select all non-hero, non-image-block images
+  // select all non-featured, default (non-images block) images
   const imgEls = Array.from(mainEl.querySelectorAll('div.section-wrapper:not(:first-of-type) > div > p > picture'));
   imgEls.forEach((imgEl) => {
     const parentEl = imgEl.parentNode;
@@ -123,8 +119,7 @@ function decorateImages(mainEl) {
     }
     const blockEl = document.createElement('div');
     // build image block nested div structure
-    blockEl.classList.add('images', 'block');
-    blockEl.setAttribute('data-block-name', 'images');
+    blockEl.classList.add('images');
     const firstNestEl = document.createElement('div');
     const secondNestEl = document.createElement('div');
     // populate images block
@@ -145,6 +140,10 @@ function decorateBlocks($main) {
   $main
     .querySelectorAll('div.section-wrapper > div > div')
     .forEach(($block) => decorateBlock($block));
+}
+
+function buildAutoBlocks(mainEl) {
+  buildImageBlocks(mainEl);
 }
 
 /**
@@ -334,7 +333,7 @@ export function decorateMain($main) {
   checkWebpFeature(() => {
     webpPolyfill($main);
   });
-  decorateImages($main);
+  buildAutoBlocks($main);
   decorateBlocks($main);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -293,7 +293,7 @@ header {
 }
 
 /* caption styling */
-main .legend {
+main .caption {
   margin-top: 1.5em;
   margin-bottom: 0.5em;
   text-align: left;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -292,3 +292,12 @@ header {
   background-color: #FFF;
 }
 
+/* caption styling */
+main .legend {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  text-align: left;
+  font-style: italic;
+  font-size: var(--body-font-size-s);
+  color: var(--color-gray-700);
+} 


### PR DESCRIPTION
## Description

- remove styling (`strong`, `em`) from inline `picture`s (images not in image blocks)
- places images (and captions, if applicable) in image block structure to prep for `decorateBlock` functionality

## Related Issue

#16 

## Motivation and Context

all images (whether inline or in image blocks) will appear on screen the same (semantically and stylistically)

## Screenshots (if appropriate):

inline image with following caption
<img width="1073" alt="inline image with following caption" src="https://user-images.githubusercontent.com/43383503/127202423-ec390018-bae4-4956-84e2-07bc21761efa.png">

inline image without caption
<img width="1024" alt="inline image without caption" src="https://user-images.githubusercontent.com/43383503/127203030-874fbf29-66c0-4de9-92db-878407411e8c.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
