### PR TITLE
refactor: add default/fallback img

### DIFF
--- a/blocks/article-header/adobe-logo.svg
+++ b/blocks/article-header/adobe-logo.svg
@@ -1,0 +1,2 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 250"><style type="text/css">.r{fill:#fa0f00;}.w{fill:#fff;}</style>
+<g><rect class="r" width="250" height="250"/></g><g><polygon class="w" points="142.4,65.9 191.7,65.9 191.7,184.1"/><polygon class="w" points="107.6,65.9 58.3,65.9 58.3,184.1"/><polygon class="w" points="125,109.5 156.4,184.1 135.8,184.1 126.4,160.3 103.4,160.3"/></g></svg>

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -77,11 +77,16 @@ main .article-byline {
 }
 
 main .article-author-image {
+  background: #fa0f00;
   margin-right: 16px;
   height: 64px;
   width: 64px;
   border-radius: 50%;
   object-fit: cover;
+}
+
+main .article-author-image img {
+  border-radius: 50%;
 }
 
 main .article-byline-info {

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -3,19 +3,20 @@ import {
   getOptimizedImageURL,
 } from '../../scripts/scripts.js';
 
-async function populateAuthorImg(imgEl, url, name) {
+async function populateAuthorImg(imgContainer, url, name) {
   const resp = await fetch(`${url}.plain.html`);
   const text = await resp.text();
   if (resp.status === 200) {
     const placeholder = document.createElement('div');
     placeholder.innerHTML = text;
-    const placeholderImg = placeholder.querySelector('img');
-    const src = placeholderImg.src.replace('width=2000', 'width=200');
-    imgEl.src = getOptimizedImageURL(src);
+    const imgEl = placeholder.querySelector('img');
+    imgEl.src.replace('width=2000', 'width=200');
     imgEl.alt = name;
-    imgEl.onerror = () => {
-      imgEl.src = '/blocks/gnav/adobe-logo.svg';
-      imgEl.removeAttribute('alt');
+    imgEl.src = getOptimizedImageURL(imgEl.src);
+    imgContainer.append(imgEl);
+    imgEl.onerror = (e) => {
+      // removing 404 img will reveal fallback background img
+      e.srcElement.remove();
     };
   }
 }
@@ -42,9 +43,9 @@ export default function decorateArticleHeader(blockEl) {
   const date = bylineContainer.firstChild.lastChild;
   date.classList.add('article-date');
   // author img
-  const authorImg = document.createElement('img');
+  const authorImg = document.createElement('div');
   authorImg.classList = 'article-author-image';
-  authorImg.src = '/blocks/gnav/adobe-logo.svg';
+  authorImg.style.backgroundImage = 'url(/blocks/article-header/adobe-logo.svg)';
   bylineContainer.prepend(authorImg);
   populateAuthorImg(authorImg, authorURL, authorName);
   // feature img

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -608,6 +608,7 @@ function registerPerformanceLogger() {
     const pols = new PerformanceObserver((entryList) => {
       const entries = entryList.getEntries();
       stamp(JSON.stringify(entries));
+      // eslint-disable-next-line no-console
       console.log(entries[0].sources[0].node);
     });
     pols.observe({ type: 'layout-shift', buffered: true });


### PR DESCRIPTION
## Description

- created new default/fallback image that adheres to style guide
- replace default/fallback `img` with image container `div` (image appears as `background-image`)
- adds author image in image container

## Related Issue

#48 

## Links

https://author-img--business-website--adobe.hlx3.page/drafts/uncled/blog/agility-empathy-purpose-steered-mastercard-during-pandemic