### PR TITLE
feat(webp): refactor webp fallback in prep for markup change

### DIFF
--- a/blocks/article-feed/article-feed.js
+++ b/blocks/article-feed/article-feed.js
@@ -1,6 +1,6 @@
 import {
   readBlockConfig,
-  getOptimizedImageURL,
+  createOptimizedPicture,
   fetchBlogArticleIndex,
 } from '../../scripts/scripts.js';
 
@@ -66,9 +66,8 @@ async function decorateArticleFeed(articleFeedEl, config, offset = 0) {
 
     const path = article.path.split('.')[0];
 
-    const imagePath = image.split('?')[0].split('_')[1];
-    const imageSrc = getOptimizedImageURL(`./media_${imagePath}?format=webply&optimize=medium&width=750`);
-    const pictureTag = `<picture><img src="${imageSrc}"></picture>`;
+    const picture = createOptimizedPicture(image, title, false, [{ width: '750' }]);
+    const pictureTag = picture.outerHTML;
     const card = document.createElement('a');
     card.className = 'article-card';
     card.href = path;

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -1,6 +1,6 @@
 import {
   buildFigure,
-  getOptimizedImageURL,
+  createOptimizedPicture,
 } from '../../scripts/scripts.js';
 
 async function populateAuthorImg(imgEl, url, name) {
@@ -10,8 +10,8 @@ async function populateAuthorImg(imgEl, url, name) {
     const placeholder = document.createElement('div');
     placeholder.innerHTML = text;
     const placeholderImg = placeholder.querySelector('img');
-    const src = placeholderImg.src.replace('width=2000', 'width=200');
-    imgEl.src = getOptimizedImageURL(src);
+    const picture = createOptimizedPicture(placeholderImg.src, name, false, [{ width: 200 }]);
+    imgEl.src = picture.querySelector('img').src;
     imgEl.alt = name;
     imgEl.onerror = () => {
       imgEl.src = '/blocks/gnav/adobe-logo.svg';

--- a/blocks/featured-article/featured-article.js
+++ b/blocks/featured-article/featured-article.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/named, import/extensions */
 
 import {
-  getOptimizedImageURL,
+  createOptimizedPicture,
   getBlogArticle,
 } from '../../scripts/scripts.js';
 
@@ -13,13 +13,9 @@ async function decorateFeaturedArticle(featuredArticleEl, articlePath, callback)
 
   const path = article.path.split('.')[0];
 
-  const imagePath = image.split('?')[0].split('_')[1];
-  const imageSrcDesktop = getOptimizedImageURL(`./media_${imagePath}?format=webply&optimize=medium&width=750`);
-  const imageSrcMobile = getOptimizedImageURL(`./media_${imagePath}?format=webply&optimize=medium&width=750`);
-  const pictureTag = `<picture>
-    <source media="(max-width: 400px)" srcset="${imageSrcMobile}">
-    <img loading="eager" src="${imageSrcDesktop}">
-  </picture>`;
+  const picture = createOptimizedPicture(image, title, true, [{ width: '750' }]);
+  const pictureTag = picture.outerHTML;
+
   const card = document.createElement('a');
   card.className = 'featured-article-card';
   card.href = path;

--- a/blocks/gnav/gnav.js
+++ b/blocks/gnav/gnav.js
@@ -1,4 +1,4 @@
-import { fetchBlogArticleIndex, getOptimizedImageURL } from '../../scripts/scripts.js';
+import { fetchBlogArticleIndex, createOptimizedPicture } from '../../scripts/scripts.js';
 
 function highlightTextElements(terms, elements) {
   elements.forEach((e) => {
@@ -61,11 +61,8 @@ async function populateSearchResults(searchTerms, searchResultsEl) {
 
       const path = e.path.split('.')[0];
 
-      const imagePath = image.split('?')[0].split('_')[1];
-      const imageSrc = getOptimizedImageURL(`./media_${imagePath}?format=webply&optimize=medium&width=2000`);
-      const pictureTag = `<picture>
-        <img src="${imageSrc}">
-      </picture>`;
+      const picture = createOptimizedPicture(image, title, false, [{ width: '750' }]);
+      const pictureTag = picture.outerHTML;
       const card = document.createElement('a');
       card.className = 'article-card';
       card.href = path;

--- a/blocks/recommended-articles/recommended-articles.js
+++ b/blocks/recommended-articles/recommended-articles.js
@@ -1,5 +1,5 @@
 import {
-  getOptimizedImageURL,
+  createOptimizedPicture,
   getBlogArticle,
 } from '../../scripts/scripts.js';
 
@@ -16,11 +16,8 @@ async function decorateRecommendedArticles(recommendedArticlesEl, paths) {
 
     const path = article.path.split('.')[0];
 
-    const imagePath = image.split('?')[0].split('_')[1];
-    const imageSrc = getOptimizedImageURL(`./media_${imagePath}?format=webply&optimize=medium&width=2000`);
-    const pictureTag = `<picture>
-      <img src="${imageSrc}">
-    </picture>`;
+    const picture = createOptimizedPicture(image, title, false, [{ width: '750' }]);
+    const pictureTag = picture.outerHTML;
     const card = document.createElement('a');
     card.className = 'article-card';
     card.href = path;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -53,49 +53,6 @@ export function addPublishDependencies(url) {
 }
 
 /**
- * Returns an image URL with optimization parameters
- * @param {string} url The image URL
- */
-export function getOptimizedImageURL(src) {
-  const url = new URL(src, window.location.href);
-  let result = src;
-  const { pathname, search } = url;
-  if (pathname.includes('media_')) {
-    const usp = new URLSearchParams(search);
-    usp.delete('auto');
-    if (!window.webpSupport) {
-      if (pathname.endsWith('.png')) {
-        usp.set('format', 'png');
-      } else if (pathname.endsWith('.gif')) {
-        usp.set('format', 'gif');
-      } else {
-        usp.set('format', 'pjpg');
-      }
-    } else {
-      usp.set('format', 'webply');
-    }
-    result = `${src.split('?')[0]}?${usp.toString()}`;
-  }
-  return (result);
-}
-
-/**
- * Resets an element's attribute to the optimized image URL.
- * @see getOptimizedImageURL
- * @param {Element} $elem The element
- * @param {string} attrib The attribute
- */
-function resetOptimizedImageURL($elem, attrib) {
-  const src = $elem.getAttribute(attrib);
-  if (src) {
-    const oSrc = getOptimizedImageURL(src);
-    if (oSrc !== src) {
-      $elem.setAttribute(attrib, oSrc);
-    }
-  }
-}
-
-/**
  * Sanitizes a name for use as class name.
  * @param {*} name The unsanitized name
  * @returns {string} The class name
@@ -373,48 +330,6 @@ export function readBlockConfig($block) {
 }
 
 /**
- * Official Google WEBP detection.
- * @param {Function} callback The callback function
- */
-function checkWebpFeature(callback) {
-  const webpSupport = sessionStorage.getItem('webpSupport');
-  if (!webpSupport) {
-    const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
-    const img = new Image();
-    img.onload = () => {
-      const result = (img.width > 0) && (img.height > 0);
-      window.webpSupport = result;
-      sessionStorage.setItem('webpSupport', result);
-      callback();
-    };
-    img.onerror = () => {
-      sessionStorage.setItem('webpSupport', false);
-      window.webpSupport = false;
-      callback();
-    };
-    img.src = `data:image/webp;base64,${kTestImages}`;
-  } else {
-    window.webpSupport = (webpSupport === 'true');
-    callback();
-  }
-}
-
-/**
- * WEBP Polyfill for older browser versions.
- * @param {Element} $elem The container element
- */
-export function webpPolyfill($elem) {
-  if (!window.webpSupport) {
-    $elem.querySelectorAll('img').forEach(($img) => {
-      resetOptimizedImageURL($img, 'src');
-    });
-    $elem.querySelectorAll('picture source').forEach(($source) => {
-      resetOptimizedImageURL($source, 'srcset');
-    });
-  }
-}
-
-/**
  * Normalizes all headings within a container element.
  * @param {Element} $elem The container element
  * @param {[string]]} allowedHeadings The list of allowed headings (h1 ... h6)
@@ -443,15 +358,67 @@ export function normalizeHeadings($elem, allowedHeadings) {
 }
 
 /**
+ * Returns a picture element with webp and fallbacks
+ * @param {string} src The image URL
+ * @param {boolean} eager load image eager
+ * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
+ */
+
+export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: 'min-width: 400px', width: '2000' }, { width: '750' }]) {
+  const url = new URL(src, window.location.href);
+  const picture = document.createElement('picture');
+  const { pathname } = url;
+  const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
+
+  // webp
+  breakpoints.forEach((br) => {
+    const source = document.createElement('source');
+    if (br.media) source.setAttribute('media', br.media);
+    source.setAttribute('type', 'image/webp');
+    source.setAttribute('srcset', `${pathname}?width=${br.width}&format=webply&optimize=medium`);
+    picture.appendChild(source);
+  });
+
+  // fallback
+  breakpoints.forEach((br, i) => {
+    if (i < breakpoints.length - 1) {
+      const source = document.createElement('source');
+      if (br.media) source.setAttribute('media', br.media);
+      source.setAttribute('srcset', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      picture.appendChild(source);
+    } else {
+      const img = document.createElement('img');
+      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      img.setAttribute('loading', eager ? 'eager' : 'lazy');
+      img.setAttribute('alt', alt);
+      picture.appendChild(img);
+    }
+  });
+
+  return picture;
+}
+
+/**
+ * Decorates the main element.
+ * @param {Element} $main The main element
+ */
+function decoratePictures($main) {
+  $main.querySelectorAll('img[src*="/media_"').forEach((img, i) => {
+    const newPicture = createOptimizedPicture(img.src, img.alt, !i);
+    const picture = img.closest('picture');
+    if (picture) picture.parentElement.replaceChild(newPicture, picture);
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} $main The main element
  */
 export function decorateMain($main) {
+  // forward compatible pictures redecoration
+  decoratePictures($main);
   buildAutoBlocks($main);
   wrapSections($main.querySelectorAll(':scope > div'));
-  checkWebpFeature(() => {
-    webpPolyfill($main);
-  });
   decorateBlocks($main);
 }
 


### PR DESCRIPTION
i am testing a more general change to the webp fallback...

https://webp-fallback--business-website--adobe.hlx3.page/blog/
https://webp-fallback--business-website--adobe.hlx3.page/blog/trends/improving-the-customer-experience-cios-look-beyond-business-technology-to-privacy

unfortunately i don't have access to a pre webp browser to see if the fallback works.

@fkakatie i changed a few things around in the author image code, i am sure that this is by no means ideal, but i think the structure may change anyway towards using a bg image for the real fallback instead of the current js based solution.

@rofe @kptdobe i think we should look at this in light of a more whole sale change across all projects and helix.