### PR TITLE
refactor(article-header): place article header in separate section

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -181,6 +181,7 @@ function buildImageBlocks(mainEl) {
  * @param {Element} mainEl The container element
  */
 function buildArticleHeader(mainEl) {
+  const div = document.createElement('div');
   const h1 = mainEl.querySelector('h1');
   const picture = mainEl.querySelector('picture');
   const category = getMetadata('category');
@@ -194,7 +195,8 @@ function buildArticleHeader(mainEl) {
       <p>${publicationDate}</p>`],
     [{ elems: [picture.closest('p'), getImageCaption(picture)] }],
   ]);
-  mainEl.firstChild.prepend(articleHeaderBlockEl);
+  div.append(articleHeaderBlockEl);
+  mainEl.prepend(div);
 }
 
 /**


### PR DESCRIPTION
`.article-header` block should appear in its own `section > div.section-wrapper` container. 

in `buildArticleHeader` func:
- `.buildArticleHeader` block is nested in containing `<div>`
- `.buildArticleHeader` is prepended to the `<main>` element

slight change in existing structure as described above enables existing functionality (`wrapSections`, `decorateBlocks`) to position `.buildArticleHeader` correctly in the DOM with appropriate classes

## Links

- https://article-header--business-website--adobe.hlx3.page/blog/trends/back-to-school-2021-how-digital-technologies-can-ease-the-return-to-in-person-education
- https://article-header--business-website--adobe.hlx3.page/blog/trends/improving-the-customer-experience-cios-look-beyond-business-technology-to-privacy
- https://article-header--business-website--adobe.hlx3.page/blog/trends/announcing-the-2021-adobe-experience-maker-awards-finalists