### PR TITLE
refactor: fix section wrapper styles

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -285,10 +285,6 @@ main .section-wrapper:first-of-type {
   padding: 0;
 }
 
-main .section-wrapper > div {
-  margin: auto;
-}
-
 @media (min-width:600px) {
   main .section-wrapper > div {
     max-width: unset;
@@ -300,13 +296,18 @@ main .section-wrapper > div:empty {
 }
 
 main .section-wrapper > div {
-  margin-left: 32px;
-  margin-right: 32px;
+  margin: auto;
   padding: 0 2rem;
 }
 
 @media (min-width: 700px) {
   main .section-wrapper > div {
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  main .section-wrapper > div > :not(div) {
     max-width: 600px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
fix styling of `div`s and non-`div`s inside `.section-wrapper` 

:warning: **NOTE:** other styling appears to be negatively impacted by change to recommended articles styling in previous PR -- will correct in future PR

## Related Issue

small piece of #60 

## Links (if appropriate)

https://section-wrapper-styling--business-website--adobe.hlx.live/drafts/uncled/blog/kitchen-sink
