### PR TITLE
refactor: block and caption styling

### DIFF
--- a/blocks/animation/animation.css
+++ b/blocks/animation/animation.css
@@ -5,7 +5,6 @@ main .animation {
 main .animation .figure {
   margin-top: 16px;
   margin-bottom: 16px;
-  line-height: 0;
   text-align: center;
 }
 
@@ -13,30 +12,5 @@ main .animation .figure {
   main .animation .figure {
     margin: 0 auto;
     max-width: 800px;
-  }
-  main .animation .figure img,
-  main .animation .figure video {
-    min-width: 600px;
-  }
-}
-
-main .animation .figure .caption {
-  padding-left: 2rem;
-  padding-right: 2rem;
-  margin: 0;
-}
-
-@media (min-width: 700px) {
-  main .animation .figure .caption {
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-}
-
-@media (min-width: 900px) {
-  main .animation .figure .caption {
-    max-width: unset;
-    padding: 0;
   }
 }

--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -5,7 +5,6 @@ main .images {
 main .images .figure {
   margin-top: 16px;
   margin-bottom: 16px;
-  line-height: 0;
   text-align: center;
 }
 
@@ -17,34 +16,8 @@ main .images .figure {
 }
 
 main .images .figure img {
-  width: 100%;
-}
-
-@media (min-width: 600px) {
-  main .images .figure img {
-    min-width: 600px;
-  }
-}
-
-main .images .figure .caption {
-  padding-left: 2rem;
-  padding-right: 2rem;
-  margin: 0;
-}
-
-@media (min-width: 700px) {
-  main .images .figure .caption {
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-}
-
-@media (min-width: 900px) {
-  main .images .figure .caption {
-    max-width: unset;
-    padding: 0;
-  }
+  max-width: 100%;
+  max-height: 600px;
 }
 
 main .images-list {
@@ -96,17 +69,4 @@ main .images-list .figure {
 main .images-list .figure img {
   width: 100%;
   min-width: unset;
-}
-
-@media (min-width: 700px) {
-  main .images-list .figure .caption {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
-
-@media (min-width: 900px) {
-  main .images-list .figure .caption {
-    padding: 0;
-  }
 }

--- a/blocks/infographic/infographic.css
+++ b/blocks/infographic/infographic.css
@@ -20,24 +20,3 @@ main .infographic .figure img {
     width: 100%;
     max-width: 600px;
 }
-
-main .infographic .figure .caption {
-    padding-left: 2rem;
-    padding-right: 2rem;
-    margin: 0;
-}
-
-@media (min-width: 700px) {
-    main .infographic .figure .caption {
-        max-width: 600px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-}     
-
-@media (min-width: 900px) {
-    main .infographic .figure .caption {
-        /* max-width: unset; */
-        padding: 0;
-    }
-}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -285,10 +285,6 @@ main .section-wrapper:first-of-type {
   padding: 0;
 }
 
-main .section-wrapper > div {
-  margin: auto;
-}
-
 @media (min-width:600px) {
   main .section-wrapper > div {
     max-width: unset;
@@ -300,13 +296,18 @@ main .section-wrapper > div:empty {
 }
 
 main .section-wrapper > div {
-  margin-left: 32px;
-  margin-right: 32px;
+  margin: auto;
   padding: 0 2rem;
 }
 
 @media (min-width: 700px) {
   main .section-wrapper > div {
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  main .section-wrapper > div > :not(div) {
     max-width: 600px;
     margin-left: auto;
     margin-right: auto;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -331,16 +331,26 @@ header {
 
 /* caption styling */
 
-main .caption {
+main .figure {
+  margin: 0;
+}
+
+main .figure .caption {
   margin-top: 16px !important;
   text-align: left;
   font-style: italic;
   font-size: var(--body-font-size-xs);
   color: var(--color-gray-700);
-} 
-main .figure .caption {
   padding: 0;
   margin: 0;
+}
+
+@media (min-width: 700px) {
+  main .figure .caption {
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 /* CLS and FOUC protection for lazy loaded content/styles */


### PR DESCRIPTION
fixes figures and captions

:warning: **NOTE:** other styling appears to be negatively impacted by change to recommended articles styling in previous PR -- will correct in future PR

## Related Issue

small part of #60 

## Screenshots and Links

https://block-caption-styling--business-website--adobe.hlx.live/drafts/uncled/blog/kitchen-sink

<img width="384" alt="animation caption before" src="https://user-images.githubusercontent.com/43383503/130500752-e8a53806-6962-475d-bf1a-e412a8e8005a.png">

<img width="386" alt="animation caption after" src="https://user-images.githubusercontent.com/43383503/130500921-e19bb341-819f-47cd-b62d-2113b5c5394b.png">
