### PR TITLE
feat: tags block

### DIFF
--- a/blocks/tags/tags.css
+++ b/blocks/tags/tags.css
@@ -1,0 +1,27 @@
+main .tags {
+  margin: 64px auto 0 auto;
+  border-top: 1px solid var(--color-gray-200);
+  max-width: 600px;
+}
+
+main .tags .tags-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+main .tags .tags-container a.button {
+  background: var(--color-white);
+  color: var(--detail-color);
+  font-weight: 400;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 4px;
+  padding: 16px;
+  margin: 0 16px 16px 0;
+  font-size: var(--detail-font-size-s);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+}
+
+main .tags .tags-container a.button:hover {
+  color: var(--color-info-accent);
+}

--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -1,5 +1,4 @@
 export default function decorateTags(blockEl) {
-  console.log('hi from decorate tags');
   const tags = blockEl.textContent.split(', ');
   const container = blockEl.querySelector('p');
   container.classList.add('tags-container');
@@ -9,7 +8,6 @@ export default function decorateTags(blockEl) {
     a.setAttribute('href', `../tags/${tag.toLowerCase().replace(' ', '-')}`);
     a.textContent = tag;
     a.classList.add('button');
-    console.log(a);
     container.append(a);
   });
 }

--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -1,0 +1,15 @@
+export default function decorateTags(blockEl) {
+  console.log('hi from decorate tags');
+  const tags = blockEl.textContent.split(', ');
+  const container = blockEl.querySelector('p');
+  container.classList.add('tags-container');
+  container.textContent = '';
+  tags.forEach((tag) => {
+    const a = document.createElement('a');
+    a.setAttribute('href', `../tags/${tag.toLowerCase().replace(' ', '-')}`);
+    a.textContent = tag;
+    a.classList.add('button');
+    console.log(a);
+    container.append(a);
+  });
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,7 +35,6 @@ export function loadCSS(href) {
 export function getMetadata(name) {
   const attr = name && name.includes(':') ? 'property' : 'name';
   const meta = [...document.head.querySelectorAll(`meta[${attr}="${name}"]`)].map((el) => el.content).join(', ');
-  // console.log(meta);
   return meta;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,8 +34,9 @@ export function loadCSS(href) {
  */
 export function getMetadata(name) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const $meta = document.head.querySelector(`meta[${attr}="${name}"]`);
-  return $meta && $meta.content;
+  const meta = [...document.head.querySelectorAll(`meta[${attr}="${name}"]`)].map((el) => el.content).join(', ');
+  // console.log(meta);
+  return meta;
 }
 
 /**
@@ -199,6 +200,21 @@ function buildArticleHeader(mainEl) {
   mainEl.prepend(div);
 }
 
+function buildTagsBlock(mainEl) {
+  const tags = getMetadata('article:tag');
+  if (tags) {
+    const tagsBlock = buildBlock('tags', [
+      [`<p>${tags}</p>`],
+    ]);
+    const recBlock = mainEl.querySelector('.recommended-articles');
+    if (recBlock) {
+      recBlock.parentNode.insertBefore(tagsBlock, recBlock);
+    } else {
+      mainEl.append(tagsBlock);
+    }
+  }
+}
+
 /**
  * Decorates all blocks in a container element.
  * @param {Element} $main The container element
@@ -218,6 +234,7 @@ function buildAutoBlocks(mainEl) {
   try {
     if (getMetadata('author') && getMetadata('publication-date') && !mainEl.querySelector('.article-header')) {
       buildArticleHeader(mainEl);
+      buildTagsBlock(mainEl);
     }
     buildImageBlocks(mainEl);
   } catch (error) {


### PR DESCRIPTION
## Description

- `getMetadata` function now queries for all name/property matches, still returns a string
- tags block is built from `article:tag` metadata as part of autoblocking
- tag block is decorated in the same way as other blocks with the `decorateBlock` functionality

## Links

https://tags-block--business-website--adobe.hlx3.page/blog/news/bon-voyage-embarking-on-journeys-that-guests-love

articles without tags are unaffected 
https://tags-block--business-website--adobe.hlx3.page/blog/trends/isobar-helps-mitsubishi-motors-australia-drive-new-car-buying-journey

