### PR TITLE
fix: add robots column

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -45,6 +45,10 @@ indices:
         select: head > meta[name="description"]
         value: |
           attribute(el, 'content')
+      robots:
+        select: head > meta[name="robots"]
+        value: |
+          attribute(el, 'content')
       lastModified:
         select: none
         value: |


### PR DESCRIPTION
adds the `<meta name="robots" content="...">` value to the index