### PR TITLE
chore: target all article:tag values

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -39,7 +39,7 @@ indices:
           attribute(el, 'content')
       tags:
         select: head > meta[property="article:tag"]
-        value: |
+        values: |
           attribute(el, 'content')
       description:
         select: head > meta[name="description"]


### PR DESCRIPTION
query multiple values for article tags