### PR TITLE
refactor: allow for new and old hlx bot uploads

### DIFF
--- a/blocks/animation/animation.js
+++ b/blocks/animation/animation.js
@@ -5,18 +5,28 @@ export default function decorateAnimation(blockEl) {
   const parentEl = a.parentNode;
   const href = a.getAttribute('href');
   const url = new URL(href);
-  const helixId = url.pathname.split('/')[2];
-  if (href.endsWith('.gif')) {
-    const picEl = `<picture>
-            <img src="./media_${helixId}.gif" />
-        </picture>`;
-    parentEl.innerHTML = picEl;
-  } else if (href.endsWith('.mp4')) {
-    const vidEl = `<video playsinline autoplay loop muted>
-            <source src="./media_${helixId}.mp4" type="video/mp4" />
-        </video>`;
-    parentEl.innerHTML = vidEl;
+  const { hostname } = url;
+  let { pathname } = url;
+
+  if (hostname.includes('hlx.blob.core')) {
+    // transform links from blob
+    const helixId = pathname.split('/')[2];
+    const type = href.includes('.mp4') ? 'mp4' : 'gif';
+    pathname = `/media_${helixId}.${type}`;
   }
+
+  if (href.includes('.mp4')) {
+    const vidEl = `<video playsinline autoplay loop muted>
+      <source src=".${pathname}" type="video/mp4" />
+    </video>`;
+    parentEl.innerHTML = vidEl;
+  } else if (href.includes('.gif')) {
+    const picEl = `<picture>
+      <img src=".${pathname}" />
+    </picture>`;
+    parentEl.innerHTML = picEl;
+  }
+
   const figEl = buildFigure(blockEl.firstChild.firstChild);
   blockEl.prepend(figEl);
   blockEl.lastChild.remove();


### PR DESCRIPTION
## Description

animation block was previously built to transform hlx.blob links
propose that animation block transform hlx.blob links and handle new-style helix bot uploads

## Related Issue

#95 

## Links

before: https://main--business-website--adobe.hlx3.page/drafts/fkakatie/authoring-a-blog-post#animation
after: https://block-animation--business-website--adobe.hlx3.page/drafts/fkakatie/authoring-a-blog-post#animation
