### PR TITLE
chore: make alt text visible in fallback

### DIFF
--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -126,6 +126,8 @@ main a.article-card:any-link {
   height: 100%;
   width: 100%;
   transition: .4s;
+  color: var(--color-white);
+  line-height: var(--body-line-height);
 }
 
 .article-card .article-card-image img:hover {


### PR DESCRIPTION
## Description

on image error in article card, alt text was impossible to read

## Screenshots

before:
<img width="486" alt="Screen Shot 2021-09-30 at 5 03 21 PM" src="https://user-images.githubusercontent.com/43383503/135540996-1edc8bcc-61a4-4df6-8d1c-25b8a9e269bc.png">

after:
<img width="425" alt="Screen Shot 2021-09-30 at 5 02 53 PM" src="https://user-images.githubusercontent.com/43383503/135540968-2eb61716-a405-4c92-b8cd-8dcf4d9251ae.png">


