### PR TITLE
refactor: article header

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -97,7 +97,8 @@ main .article-byline {
   padding: 0 2rem;
 }
 
-main .article-byline .article-author-image {
+main .article-byline .article-author-image,
+main .article-byline .article-author-image img {
   margin: 0;
   background: #fa0f00;
   margin-right: 16px;
@@ -107,9 +108,12 @@ main .article-byline .article-author-image {
   object-fit: cover;
 }
 
-main .article-byline .article-author-image img {
+/* main .article-byline .article-author-image img {
   border-radius: 50%;
-}
+  height: 64px;
+  width: 64px;
+  object-fit: cover;
+} */
 
 main .article-byline .article-byline-info {
   margin: 0;

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -108,13 +108,6 @@ main .article-byline .article-author-image img {
   object-fit: cover;
 }
 
-/* main .article-byline .article-author-image img {
-  border-radius: 50%;
-  height: 64px;
-  width: 64px;
-  object-fit: cover;
-} */
-
 main .article-byline .article-byline-info {
   margin: 0;
   display: flex;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -342,7 +342,7 @@ function decorateBlocks($main) {
 function buildAutoBlocks(mainEl) {
   removeStylingFromImages(mainEl);
   try {
-    if (getMetadata('author') && getMetadata('publication-date') && !mainEl.querySelector('.article-header')) {
+    if (getMetadata('publication-date') && !mainEl.querySelector('.article-header')) {
       buildArticleHeader(mainEl);
       buildTagsBlock(mainEl);
       interlink(mainEl);


### PR DESCRIPTION
## Description

- fix author img styles
- auto-block article header without author

## Links

no author before: https://main--business-website--adobe.hlx3.page/blog/insights/emotional-analytics
no author after: https://article-header--business-website--adobe.hlx3.page/blog/insights/emotional-analytics

author img before: https://main--business-website--adobe.hlx3.page/blog/news/agility-empathy-purpose-steered-mastercard-during-pandemic
author img after: https://article-header--business-website--adobe.hlx3.page/blog/news/agility-empathy-purpose-steered-mastercard-during-pandemic
