### PR TITLE
refactor: first img  uses larger width

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -554,7 +554,7 @@ export function normalizeHeadings($elem, allowedHeadings) {
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 
-export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: 'min-width: 400px', width: '2000' }, { width: '750' }]) {
+export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
   const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
   const { pathname } = url;
@@ -624,12 +624,7 @@ export function buildArticleCard(article, type = 'article') {
  */
 function decoratePictures($main) {
   $main.querySelectorAll('img[src*="/media_"').forEach((img, i) => {
-    let newPicture;
-    if (i === 0) { // load larger first img
-      newPicture = createOptimizedPicture(img.src, img.alt, !i, [{ width: '2000' }]);
-    } else {
-      newPicture = createOptimizedPicture(img.src, img.alt, !i);
-    }
+    const newPicture = createOptimizedPicture(img.src, img.alt, !i);
     const picture = img.closest('picture');
     if (picture) picture.parentElement.replaceChild(newPicture, picture);
   });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -624,7 +624,12 @@ export function buildArticleCard(article, type = 'article') {
  */
 function decoratePictures($main) {
   $main.querySelectorAll('img[src*="/media_"').forEach((img, i) => {
-    const newPicture = createOptimizedPicture(img.src, img.alt, !i);
+    let newPicture;
+    if (i === 0) { // load larger first img
+      newPicture = createOptimizedPicture(img.src, img.alt, !i, [{ width: '2000' }]);
+    } else {
+      newPicture = createOptimizedPicture(img.src, img.alt, !i);
+    }
     const picture = img.closest('picture');
     if (picture) picture.parentElement.replaceChild(newPicture, picture);
   });


### PR DESCRIPTION
## Description

~~featured images in article header were using 750px width~~
~~propose first image to be optimized uses 2000px width~~

correct default media query

images in cards are unaffected

## Links
before: https://main--business-website--adobe.hlx3.page/blog/basics/digital-success-for-small-businesses-with-adobe-sign
after: https://larger-first-img--business-website--adobe.hlx3.page/blog/basics/digital-success-for-small-businesses-with-adobe-sign