### PR TITLE
feat: exclude non-article paths

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -9,9 +9,9 @@ indices:
       - '/blog/**'
     exclude:
       - '/blog/'
-      - '/blog/index**'
-      - '/blog/gnav**'
-      - '/blog/footer**'
+      - '/blog/index*'
+      - '/blog/gnav*'
+      - '/blog/footer*'
       - '/blog/authors/**'
       - '/blog/banners/**'
       - '/blog/categories/**'


### PR DESCRIPTION
Fix #94

I took the `exclude` path because the list of categories in which the articles are stored will certainly change (add more categories). We would then need to change the indexing rules. The list of thing to exclude will be pretty stable I assume.

@dominique-pfister how would I test that my rules are correctly defined ?