### PR TITLE
chore: remove fouc

### DIFF
--- a/blocks/featured-article/featured-article.css
+++ b/blocks/featured-article/featured-article.css
@@ -10,7 +10,7 @@
   }
 }
 
-main .featured-article {
+main .featured-article.loaded {
   visibility: unset;
 }
 

--- a/blocks/featured-article/featured-article.js
+++ b/blocks/featured-article/featured-article.js
@@ -16,6 +16,7 @@ async function decorateFeaturedArticle(featuredArticleEl, articlePath, callback)
     } else {
       featuredArticleEl.append(card);
     }
+    featuredArticleEl.classList.add('loaded');
     if (callback) callback();
   } else {
     const { origin } = new URL(window.location.href);


### PR DESCRIPTION
there is a short flash-of-undecorated content in the event that the `.css` is loaded but the `.js` is not executed yet.

https://featured-article-block--business-website--adobe.hlx3.page/blog/
https://main--business-website--adobe.hlx3.page/blog/
