### PR TITLE
fix: remove flex for bottom position footer

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -13,7 +13,6 @@ footer .footer {
   max-width: 1440px;
   margin: auto;
   width: 100%;
-  flex-shrink: 0; /* For bottom aligned footer */
 }
 
 @media (min-width: 600px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -68,11 +68,6 @@
   }
 }
 
-html,
-body {
-  height: 100%; /* For bottom aligned footer */
-}
-
 body {
   background-color: var(--body-background-color);
   font-family: var(--body-font-family);
@@ -80,9 +75,6 @@ body {
   color: var(--body-color);
   margin: 0;
   padding: 0;
-  /* For bottom aligned footer */
-  display: flex;
-  flex-direction: column;
 }
 
 /* buttons */
@@ -197,7 +189,6 @@ main {
   line-height: var(--body-line-height);
   margin: 64px 0 0 0;
   font-weight: var(--body-font-weight);
-  flex: 1 0 auto; /* For bottom aligned footer */
 }
 
 main p:not(:last-of-type) {


### PR DESCRIPTION
## Description

remove flex on `html`, `body` for bottom positioned footer
(pages without enough content to fill viewport height are probably not fully completed pages)