### PR TITLE
feat: implement fetch index as a singleton

### DIFF
--- a/blocks/article-feed/article-feed.js
+++ b/blocks/article-feed/article-feed.js
@@ -1,7 +1,7 @@
 import {
   readBlockConfig,
   buildArticleCard,
-  fetchBlogArticleIndex,
+  getBlogArticleIndex,
   fetchPlaceholders,
 } from '../../scripts/scripts.js';
 
@@ -12,10 +12,7 @@ function isCardOnPage(article) {
 }
 
 async function filterArticles(config) {
-  if (!window.blogIndex) {
-    window.blogIndex = await fetchBlogArticleIndex();
-  }
-  const index = window.blogIndex;
+  const index = await getBlogArticleIndex();
 
   const result = [];
 

--- a/blocks/gnav/gnav-search.js
+++ b/blocks/gnav/gnav-search.js
@@ -1,4 +1,4 @@
-import { fetchBlogArticleIndex, createOptimizedPicture } from '../../scripts/scripts.js';
+import { getBlogArticleIndex, createOptimizedPicture } from '../../scripts/scripts.js';
 import createTag from './gnav-utils.js';
 
 function decorateCard(hit) {
@@ -52,11 +52,8 @@ async function populateSearchResults(searchTerms, resultsContainer) {
   resultsContainer.innerHTML = '';
 
   if (terms.length) {
-    if (!window.blogIndex) {
-      window.blogIndex = await fetchBlogArticleIndex();
-    }
-
-    const articles = window.blogIndex.data;
+    const index = await getBlogArticleIndex();
+    const articles = index.data;
 
     const hits = [];
     let i = 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -705,7 +705,7 @@ export function addFavIcon(href) {
  * @returns {object} index with data and path lookup
  */
 
-export async function fetchBlogArticleIndex() {
+async function fetchBlogArticleIndex() {
   const resp = await fetch(`${getRootPath()}/query-index.json`);
   const json = await resp.json();
   const byPath = {};
@@ -716,6 +716,25 @@ export async function fetchBlogArticleIndex() {
   return (index);
 }
 
+let pendingFetchBlogArticleIndex;
+export async function getBlogArticleIndex() {
+  if (window.blogIndex) return window.blogIndex;
+
+  if (pendingFetchBlogArticleIndex) {
+    return pendingFetchBlogArticleIndex;
+  }
+
+  pendingFetchBlogArticleIndex = new Promise((resolve) => {
+    fetchBlogArticleIndex().then((index) => {
+      window.blogIndex = index;
+      resolve(window.blogIndex);
+      pendingFetchBlogArticleIndex = null;
+    });
+  });
+
+  return pendingFetchBlogArticleIndex;
+}
+
 /**
  * gets a blog article index information by path.
  * @param {string} path indentifies article
@@ -723,10 +742,7 @@ export async function fetchBlogArticleIndex() {
  */
 
 export async function getBlogArticle(path) {
-  if (!window.blogIndex) {
-    window.blogIndex = await fetchBlogArticleIndex();
-  }
-  const index = window.blogIndex;
+  const index = await getBlogArticleIndex();
   return (index.byPath[path]);
 }
 


### PR DESCRIPTION
Fetch index as a singleton and respecting potential concurrent accesses.

Check network tab for `query-index.json` after page load:

Before:
- https://main--business-website--adobe.hlx3.page/drafts/alex/blog/test (x3)

After:
- https://fetch-as-singleton--business-website--adobe.hlx3.page/drafts/alex/blog/test (x1)

