### PR TITLE
feat: introduce metadata.json concept

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -726,9 +726,10 @@ export async function fetchBlogArticleIndex() {
 async function getMetadataJson(path) {
   const resp = await fetch(path.split('.')[0]);
   const text = await resp.text();
-  const html = document.createElement('html');
-  html.innerHTML = text;
-  const metaTags = html.querySelectorAll('head > meta');
+  const headStr = text.split('<head>')[1].split('</head>')[0];
+  const head = document.createElement('head');
+  head.innerHTML = headStr;
+  const metaTags = head.querySelectorAll(':scope > meta');
   const meta = {};
   metaTags.forEach((metaTag) => {
     const name = metaTag.getAttribute('name') || metaTag.getAttribute('property');


### PR DESCRIPTION
in an effort to compress the LCP time we were talking about changing the way how featured and recommended articles are loaded. instead of loading the index, we load a currently fictitious `.metadata.json` of a page as an experiment if the `getMetadataJson()` method could be pervasive enough to eventually be ported over to the pipeline service...

https://metadata-json--business-website--adobe.hlx.live/blog/
vs.
https://main--business-website--adobe.hlx.live/blog/

<img width="675" alt="Screen Shot 2021-10-20 at 3 58 59 PM" src="https://user-images.githubusercontent.com/5289336/138178399-e7b9f647-2bdd-48c6-8e34-10cce0d98daf.png">

<img width="677" alt="Screen Shot 2021-10-20 at 3 59 42 PM" src="https://user-images.githubusercontent.com/5289336/138178485-308536e6-3b4d-4c58-b0e5-61d95b9a563f.png">


