### PR TITLE
feat: integrate Privacy

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -11,7 +11,7 @@
  */
 
 /* globals webVitals */
-import { loadScript, sampleRUM } from './scripts.js';
+import { loadScript, sampleRUM, getHelixEnv } from './scripts.js';
 
 function updateExternalLinks() {
   document.querySelectorAll('main a, footer a').forEach((a) => {
@@ -51,3 +51,30 @@ if (window.hlx.rum.isSelected) {
   };
   document.head.appendChild(script);
 }
+
+function loadPrivacy() {
+  function getOtDomainId() {
+    const domains = {
+      'adobe.com': '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
+      'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271',
+    };
+
+    const currentDomain = Object.keys(domains)
+      .find((domain) => window.location.host.indexOf(domain) > -1);
+
+    return `${domains[currentDomain] || domains[Object.keys(domains)[0]]}`;
+  }
+
+  // Configure Privacy
+  window.fedsConfig = {
+    privacy: {
+      otDomainId: getOtDomainId(),
+      footerLinkSelector: '[href="#openPrivacy"]',
+    },
+  };
+
+  const env = getHelixEnv().name === 'prod' ? '' : 'stage.';
+  loadScript(`https://www.${env}adobe.com/etc/beagle/public/globalnav/adobe-privacy/latest/privacy.min.js`);
+}
+
+loadPrivacy();


### PR DESCRIPTION
## Description
Integrate Privacy.js and add support for GDPR. Fixes #124 

**Note:** The "cookie preferences" href needs to be changed to `#openPrivacy`, otherwise the Preference Center modal will not be visible after clicking.

URL for testing:
- https://main--business-website--narcis-radu.hlx3.page/

## Motivation and Context
Adds support for GDPR

## How Has This Been Tested?
Locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
