### PR TITLE
fix: remove description on small featured articles block

### DIFF
--- a/blocks/recommended-articles/recommended-articles.css
+++ b/blocks/recommended-articles/recommended-articles.css
@@ -42,6 +42,10 @@ main div.recommended-articles-small-content-wrapper {
   margin: 0 auto;
 }
 
+main div.recommended-articles-small-container .article-card .article-card-body p {
+  display: none;
+}
+
 @media (min-width: 700px) {
   main div.recommended-articles-small-content-wrapper {
     width: calc(100% - 64px);


### PR DESCRIPTION
## Description

remove description from recommended articles (small) 

## Related Issue

#133 

## Links

before: https://main--business-website--adobe.hlx3.page/blog/
after: https://small-rec-articles--business-website--adobe.hlx3.page/blog/
