### PR TITLE
feat: selective target loading and unhiding

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,13 +1,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<style id="alloy-prehiding">body{opacity:0.01 !important}</style>
-<script>
-setTimeout(function () {
-  var s = document.getElementById('alloy-prehiding');
-  try {
-    (s && s.parentNode) && s.parentNode.removeChild(s);
-  } catch (e) {}
-}, 3000);
-</script>
 <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -155,14 +155,12 @@ export function getHelixEnv() {
       adobeIO: 'cc-collab-stage.adobe.io',
       adminconsole: 'stage.adminconsole.adobe.com',
       account: 'stage.account.adobe.com',
-      target: false,
     },
     prod: {
       ims: 'prod',
       adobeIO: 'cc-collab.adobe.io',
       adminconsole: 'adminconsole.adobe.com',
       account: 'account.adobe.com',
-      target: true,
     },
   };
   const env = envs[envName];
@@ -840,14 +838,121 @@ export function loadScript(url, callback, type) {
   return script;
 }
 
+function unhideBody(id) {
+  try {
+    document.head.removeChild(document.getElementById(id));
+  } catch (e) {
+    // nothing
+  }
+}
+
+function hideBody(id) {
+  const style = document.createElement('style');
+  style.id = id;
+  style.innerHTML = 'body{visibility: hidden !important}';
+
+  try {
+    document.head.appendChild(style);
+  } catch (e) {
+    // nothing
+  }
+}
+
+/**
+ * sets digital data
+ */
+
+async function setDigitalData(digitaldata) {
+  digitaldata.page.pageInfo.category = 'unknown: before instrumentation.json';
+  const resp = await fetch('/blog/instrumentation.json');
+  const json = await resp.json();
+  delete digitaldata.page.pageInfo.category;
+
+  const digitalDataMap = json.digitaldata.data;
+  digitalDataMap.forEach((mapping) => {
+    const metaValue = getMetadata(mapping.metadata);
+    if (metaValue) {
+      // eslint-disable-next-line no-underscore-dangle
+      digitaldata._set(mapping.digitaldata, metaValue);
+    }
+  });
+}
+
+async function loadMartech() {
+  const usp = new URLSearchParams(window.location.search);
+  const alloy = usp.get('alloy');
+
+  // set data layer properties
+  window.digitalData = {
+    page: {
+      pageInfo: {
+        language: LANG_LOC[getLanguage()] || '',
+        category: 'unknown: before setDigitalData()',
+      },
+    },
+  };
+
+  const target = getMetadata('target').toLocaleLowerCase() === 'on';
+
+  // load bootstrap script
+  let bootstrapScriptUrl = 'https://www.adobe.com/marketingtech/';
+  if (alloy === 'on') {
+    window.marketingtech = {
+      adobe: {
+        target,
+        launch: {
+          url: 'https://assets.adobedtm.com/d4d114c60e50/cf25c910a920/launch-1bba233684fa-development.js',
+          load: (l) => {
+            const delay = () => (
+              setTimeout(l, 3500)
+            );
+            if (document.readyState === 'complete') {
+              delay();
+            } else {
+              window.addEventListener('load', delay);
+            }
+          },
+        },
+      },
+    };
+    bootstrapScriptUrl += 'main.alloy.min.js';
+  } else {
+    window.marketingtech = {
+      adobe: {
+        target,
+        audienceManager: true,
+        launch: {
+          property: 'global',
+          environment: 'production',
+        },
+      },
+    };
+    window.targetGlobalSettings = window.targetGlobalSettings || {};
+    bootstrapScriptUrl += 'main.min.js';
+  }
+
+  loadScript(bootstrapScriptUrl, () => {
+    setDigitalData(window.digitalData);
+  });
+}
+
 /**
  * loads everything needed to get to LCP.
  */
 async function loadEager() {
   const main = document.querySelector('main');
   if (main) {
+    const bodyHideStyleId = 'at-body-style';
     decorateMain(main);
     document.querySelector('body').classList.add('appear');
+    const target = getMetadata('target').toLocaleLowerCase() === 'on';
+    if (target) {
+      hideBody(bodyHideStyleId);
+      setTimeout(() => {
+        unhideBody(bodyHideStyleId);
+      }, 3000);
+    }
+
     const lcpBlocks = ['featured-article', 'article-header'];
     const block = document.querySelector('.block');
     const hasLCPBlock = (block && lcpBlocks.includes(block.getAttribute('data-block-name')));
@@ -892,6 +997,7 @@ async function loadLazy() {
   loadBlocks(main);
   loadCSS('/styles/lazy-styles.css');
   addFavIcon('/styles/favicon.svg');
+  loadMartech();
 }
 
 /**
@@ -915,89 +1021,10 @@ function loadDelayed() {
 }
 
 /**
- * sets digital data
- */
-
-async function setDigitalData(digitaldata) {
-  digitaldata.page.pageInfo.category = 'unknown: before instrumentation.json';
-  const resp = await fetch('/blog/instrumentation.json');
-  const json = await resp.json();
-  delete digitaldata.page.pageInfo.category;
-
-  const digitalDataMap = json.digitaldata.data;
-  digitalDataMap.forEach((mapping) => {
-    const metaValue = getMetadata(mapping.metadata);
-    if (metaValue) {
-      // eslint-disable-next-line no-underscore-dangle
-      digitaldata._set(mapping.digitaldata, metaValue);
-    }
-  });
-}
-
-async function loadMartech() {
-  const env = getHelixEnv();
-  const usp = new URLSearchParams(window.location.search);
-  const alloy = usp.get('alloy');
-
-  // set data layer properties
-  window.digitalData = {
-    page: {
-      pageInfo: {
-        language: LANG_LOC[getLanguage()] || '',
-        category: 'unknown: before setDigitalData()',
-      },
-    },
-  };
-
-  // load bootstrap script
-  let bootstrapScriptUrl = 'https://www.adobe.com/marketingtech/';
-  if (alloy === 'on') {
-    window.marketingtech = {
-      adobe: {
-        target: env.target,
-        launch: {
-          url: 'https://assets.adobedtm.com/d4d114c60e50/cf25c910a920/launch-1bba233684fa-development.js',
-          load: (l) => {
-            const delay = () => (
-              setTimeout(l, 3500)
-            );
-            if (document.readyState === 'complete') {
-              delay();
-            } else {
-              window.addEventListener('load', delay);
-            }
-          },
-        },
-      },
-    };
-    bootstrapScriptUrl += 'main.alloy.min.js';
-  } else {
-    window.marketingtech = {
-      adobe: {
-        target: env.target,
-        audienceManager: true,
-        launch: {
-          property: 'global',
-          environment: 'production',
-        },
-      },
-    };
-    window.targetGlobalSettings = window.targetGlobalSettings || {};
-    window.targetGlobalSettings.bodyHidingEnabled = false;
-    bootstrapScriptUrl += 'main.min.js';
-  }
-
-  loadScript(bootstrapScriptUrl, () => {
-    setDigitalData(window.digitalData);
-  });
-}
-
-/**
  * Decorates the page.
  */
 async function decoratePage() {
   await loadEager();
-  loadMartech();
   loadLazy();
   loadDelayed();
 }


### PR DESCRIPTION
refactoring prehide to take `target` metadata into configuration, only if target is turned on via metadata, prehide is active and target is loaded.

https://prehide-refactor--business-website--adobe.hlx.live/blog/
https://prehide-refactor--business-website--adobe.hlx.live/drafts/uncled/blog/25-years-evolution-technology-changed-lives

this should also take care of the `SI` issue. interestingly enough, i see on `PSI` an `LCP` issue that i am not able to reproduce, in my browser.