### PR TITLE
fix: update padding in small recommended article block

### DIFF
--- a/blocks/recommended-articles/recommended-articles.css
+++ b/blocks/recommended-articles/recommended-articles.css
@@ -78,6 +78,10 @@ main div.recommended-articles-small-content-wrapper p {
 
 }
 
+main .recommended-articles-small-container .article-cards {
+  padding-top: 1rem;
+}
+
 main .recommended-articles-small-container .article-card {
   display: flex;
   width: 100%;


### PR DESCRIPTION
## Description

<img width="690" alt="Screen Shot 2021-11-09 at 4 44 52 PM" src="https://user-images.githubusercontent.com/43383503/141023500-d1c5f5c3-d6ac-4b9f-91c8-5a43dd5407de.png">

## Links

before: https://main--business-website--adobe.hlx3.page/blog/
after: https://small-rec-article-padding--business-website--adobe.hlx3.page/blog/