### PR TITLE
fix: store placeholders in window obj to reduce repeat calls

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -818,7 +818,7 @@ export async function fetchPlaceholders() {
       window.placeholders[placeholder.Key] = placeholder.Text;
     });
   }
-  return (window.placeholders);
+  return window.placeholders;
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -810,13 +810,15 @@ export async function getBlogArticle(path) {
  */
 
 export async function fetchPlaceholders() {
-  const resp = await fetch(`${getRootPath()}/placeholders.json`);
-  const json = await resp.json();
-  const placeholders = {};
-  json.data.forEach((placeholder) => {
-    placeholders[placeholder.Key] = placeholder.Text;
-  });
-  return (placeholders);
+  if (!window.placeholders) {
+    const resp = await fetch(`${getRootPath()}/placeholders.json`);
+    const json = await resp.json();
+    window.placeholders = {};
+    json.data.forEach((placeholder) => {
+      window.placeholders[placeholder.Key] = placeholder.Text;
+    });
+  }
+  return (window.placeholders);
 }
 
 /**


### PR DESCRIPTION
## Description

store placeholders in window obj to reduce repeat calls

## Related Issue

#134 

## Links 

https://cache-placeholders--business-website--adobe.hlx3.page/blog/