### PR TITLE
chore: path rewrite

### DIFF
--- a/blocks/featured-article/featured-article.js
+++ b/blocks/featured-article/featured-article.js
@@ -3,6 +3,7 @@
 import {
   buildArticleCard,
   getBlogArticle,
+  rewritePath,
 } from '../../scripts/scripts.js';
 
 async function decorateFeaturedArticle(featuredArticleEl, articlePath) {
@@ -28,7 +29,7 @@ export default async function decorate(block, blockName, document, callback) {
   const a = block.querySelector('a');
   block.innerHTML = '';
   if (a && a.href) {
-    const path = new URL(a.href).pathname;
+    const path = rewritePath(new URL(a.href).pathname);
     await decorateFeaturedArticle(block, path, callback);
   }
 }

--- a/blocks/recommended-articles/recommended-articles.js
+++ b/blocks/recommended-articles/recommended-articles.js
@@ -2,6 +2,7 @@ import {
   buildArticleCard,
   getBlogArticle,
   fetchPlaceholders,
+  rewritePath,
 } from '../../scripts/scripts.js';
 
 async function decorateRecommendedArticles(recommendedArticlesEl, paths) {
@@ -19,7 +20,7 @@ async function decorateRecommendedArticles(recommendedArticlesEl, paths) {
   const articleCardsContainer = document.createElement('div');
   articleCardsContainer.className = 'article-cards';
   for (let i = 0; i < paths.length; i += 1) {
-    const articlePath = paths[i];
+    const articlePath = rewritePath(paths[i]);
     // eslint-disable-next-line no-await-in-loop
     const article = await getBlogArticle(articlePath);
     if (article) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -751,6 +751,21 @@ export async function fetchBlogArticleIndex() {
   return (index);
 }
 
+export function rewritePath(path) {
+  let newpath = path;
+  const replacements = [{
+    from: 'news',
+    to: 'the-latest',
+  }, {
+    from: 'insights',
+    to: 'perspectives',
+  }];
+  replacements.forEach((r) => {
+    newpath = newpath.replace(`/${r.from}/`, `/${r.to}/`);
+  });
+  return newpath;
+}
+
 /**
  * forward looking *.metadata.json experiment
  * fetches metadata.json of page


### PR DESCRIPTION
due to last minute changes the `recommend-articles` and `featured-article` references are no longer correct, so i temporarily put in a path rewriter to avoid having to go and change all the URLs short term...

compare:
https://path-rewrite--business-website--adobe.hlx3.page/blog/
vs. 
https://main--business-website--adobe.hlx3.page/blog/
