### PR TITLE
chore: better tag url construction

### DIFF
--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -9,7 +9,13 @@ export default function decorateTags(blockEl) {
   container.textContent = '';
   tags.forEach((tag) => {
     const a = document.createElement('a');
-    a.setAttribute('href', `../tags/${toClassName(tag)}`);
+    let tagname = '';
+    toClassName(tag).split('-').forEach((e, i) => {
+      if (e) {
+        tagname += `${i ? '-' : ''}${e}`;
+      }
+    });
+    a.setAttribute('href', `../tags/${tagname}`);
     a.textContent = tag;
     a.classList.add('button');
     container.append(a);


### PR DESCRIPTION
see `documents and e-signatures` tag link at the bottom

https://tags-urls--business-website--adobe.hlx3.page/blog/how-to/quick-guide-to-digitizing-liability-waivers-in-education

vs.

https://main--business-website--adobe.hlx3.page/blog/how-to/quick-guide-to-digitizing-liability-waivers-in-education