### PR TITLE
fix: handle anchors without href when updating external links

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -15,6 +15,10 @@ import { loadScript, sampleRUM, getHelixEnv } from './scripts.js';
 
 function updateExternalLinks() {
   document.querySelectorAll('main a, footer a').forEach((a) => {
+    if (!a.href) {
+      return;
+    }
+
     const { origin } = new URL(a);
     if (origin && origin !== window.location.origin) {
       a.setAttribute('rel', 'noopener');


### PR DESCRIPTION
## Description
Errors are visible in the console when executing the `updateExternalLinks` method. This is because some of the anchors don't have a valid href and `new URL(a)` will fail.
The fix will check for href existence before doing a `new URL(a)`.

https://link-issue--business-website--adobe.hlx3.page/blog/

## Related Issue
#167 

## Motivation and Context
Issue is breaking the script and PrivacyJS is not loaded anymore.

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
