### PR TITLE
fix: resolve bug in build figure function

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -148,8 +148,8 @@ const loadEmbed = (block) => {
     return;
   }
 
-  const a = block.querySelector('a');
   const figure = buildFigure(block.firstChild.firstChild);
+  const a = figure.querySelector('a');
 
   if (a) {
     const url = new URL(a.href.replace(/\/$/, ''));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -485,34 +485,38 @@ export function buildCaption(pEl) {
 export function buildFigure(blockEl) {
   const figEl = document.createElement('figure');
   figEl.classList.add('figure');
-  // content is picture only, no caption or link
-  if (blockEl.firstChild) {
-    if (blockEl.firstChild.nodeName === 'PICTURE' || blockEl.firstChild.nodeName === 'VIDEO') {
-      figEl.append(blockEl.firstChild);
-    } else if (blockEl.firstChild.nodeName === 'P') {
-      const pEls = Array.from(blockEl.children);
-      pEls.forEach((pEl) => {
-        if (pEl.firstChild) {
-          if (pEl.firstChild.nodeName === 'PICTURE' || pEl.firstChild.nodeName === 'VIDEO') {
-            figEl.append(pEl.firstChild);
-          } else if (pEl.firstChild.nodeName === 'EM') {
-            const figCapEl = buildCaption(pEl);
-            figEl.append(figCapEl);
-          } else if (pEl.firstChild.nodeName === 'A') {
-            const picEl = figEl.querySelector('picture');
-            if (picEl) {
-              pEl.firstChild.textContent = '';
-              pEl.firstChild.append(picEl);
-            }
-            figEl.prepend(pEl.firstChild);
-          }
+  blockEl.childNodes.forEach((child) => {
+    const clone = child.cloneNode(true);
+    // picture, video, or embed link is NOT wrapped in P tag
+    if (clone.nodeName === 'PICTURE' || clone.nodeName === 'VIDEO' || clone.nodeName === 'A') {
+      figEl.prepend(clone);
+    } else {
+      // content wrapped in P tag(s)
+      const picture = clone.querySelector('picture');
+      if (picture) {
+        figEl.prepend(picture);
+      }
+      const video = clone.querySelector('video');
+      if (video) {
+        figEl.prepend(video);
+      }
+      const caption = clone.querySelector('em');
+      if (caption) {
+        const figElCaption = buildCaption(caption);
+        figEl.append(figElCaption);
+      }
+      const link = clone.querySelector('a');
+      if (link) {
+        const img = figEl.querySelector('picture') || figEl.querySelector('video');
+        if (img) {
+          // wrap picture or video in A tag
+          link.textContent = '';
+          link.append(img);
         }
-      });
-    // catch link-only figures (like embed blocks);
-    } else if (blockEl.firstChild.nodeName === 'A') {
-      figEl.append(blockEl.firstChild);
+        figEl.prepend(link);
+      }
     }
-  }
+  });
   return figEl;
 }
 


### PR DESCRIPTION
## Description

fix bug in the `buildFigure` function that would omit captions and links when `picture`, `video`, or `a` elements were not wrapped in `p` tag

## Related Issue

Port functionality from blog [issue #99](https://github.com/adobe/blog/issues/99), [PR #120](https://github.com/adobe/blog/pull/120)

## Links

https://build-figure-fix--business-website--adobe.hlx3.page/drafts/uncled/blog/kitchen-sink