### PR TITLE
Show embed blocks on render

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -178,7 +178,7 @@ const loadEmbed = (block) => {
       block.classList.add(`embed-${config.type}`);
     } else {
       a.outerHTML = getDefaultEmbed(url);
-      block.classList = `block embed block-visible embed-${simpleDomain}`;
+      block.classList.add(`embed-${simpleDomain}`);
     }
     block.innerHTML = figure.outerHTML;
     block.classList.add('is-loaded');

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -175,10 +175,10 @@ const loadEmbed = (block) => {
     // loading embed function for given config and url.
     if (config) {
       a.outerHTML = config.embed(url);
-      block.classList = `block embed embed-${config.type}`;
+      block.classList = `block embed block-visible embed-${config.type}`;
     } else {
       a.outerHTML = getDefaultEmbed(url);
-      block.classList = `block embed embed-${simpleDomain}`;
+      block.classList = `block embed block-visible embed-${simpleDomain}`;
     }
     block.innerHTML = figure.outerHTML;
     block.classList.add('is-loaded');

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -175,7 +175,7 @@ const loadEmbed = (block) => {
     // loading embed function for given config and url.
     if (config) {
       a.outerHTML = config.embed(url);
-      block.classList = `block embed block-visible embed-${config.type}`;
+      block.classList.add(`embed-${config.type}`);
     } else {
       a.outerHTML = getDefaultEmbed(url);
       block.classList = `block embed block-visible embed-${simpleDomain}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding the block-visible class on the loadEmbed function.

Testing URL: 
https://embed-show--business-website--adobe.hlx3.page/blog/perspectives/four-dashboards-digital-b2b-merchants-should-be-watching

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/business-website/issues/181
https://github.com/adobe/business-website/issues/180

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
