### PR TITLE
fix: use https for geo linker

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -134,5 +134,5 @@ const intl = sessionStorage.getItem('blog-international') || getCookie('internat
 if (intl) {
   setLinksToGeo({ country: intl });
 } else {
-  loadScript('http://geo2.adobe.com/json/?callback=setLinksToGeo');
+  loadScript('https://geo2.adobe.com/json/?callback=setLinksToGeo');
 }


### PR DESCRIPTION
On all https://business.adobe.com/blog/ pages, there is this error in the console: 

```
scripts.js:965 Mixed Content: The page at 'https://business.adobe.com/blog/' was loaded over HTTPS, but requested an insecure script 'http://geo2.adobe.com/json/?callback=setLinksToGeo'. This request has been blocked; the content must be served over HTTPS.
```

Request to http://geo2.adobe.com/json/?callback=setLinksToGeo and https://geo2.adobe.com/json/?callback=setLinksToGeo seems to return the same result, why not using the https version ?

Test page: https://fix-mixed-content--business-website--adobe.hlx3.page/blog/