### PR TITLE
Adding eventListener for custom event from gnav.init() and match the …

### DIFF
--- a/blocks/gnav/gnav.js
+++ b/blocks/gnav/gnav.js
@@ -447,10 +447,12 @@ export default async function init(blockEl) {
     const html = await fetchGnav(url);
     if (html) {
       try {
+        const initEvent = new Event('gnav.init');
         const parser = new DOMParser();
         const gnavDoc = parser.parseFromString(html, 'text/html');
         const gnav = new Gnav(gnavDoc.body, blockEl);
         gnav.init();
+        blockEl.dispatchEvent(initEvent);
       } catch {
         debug('Could not create global navigation.');
       }

--- a/blocks/gnav/gnav.js
+++ b/blocks/gnav/gnav.js
@@ -447,7 +447,7 @@ export default async function init(blockEl) {
     const html = await fetchGnav(url);
     if (html) {
       try {
-        const initEvent = new Event('gnav.init');
+        const initEvent = new Event('gnav:init');
         const parser = new DOMParser();
         const gnavDoc = parser.parseFromString(html, 'text/html');
         const gnav = new Gnav(gnavDoc.body, blockEl);

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -119,6 +119,7 @@ function setLinksToGeo(location) {
   sessionStorage.setItem('blog-international', location.country);
   if (location.country && glocalCountries.includes(location.country.toLowerCase())) {
     const prefix = `/${location.country.toLowerCase()}`;
+    // eslint-disable-next-line no-console
     console.log(`setting links to: ${prefix}`);
     document.querySelectorAll('a[href^="https://business.adobe.com"], a[href^="https://www.adobe.com"]').forEach((a) => {
       const url = new URL(a.href);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1216,7 +1216,13 @@ async function loadfooterBanner(main) {
     responseEl.classList.add('section');
     const bannerCTABlock = responseEl.querySelector('div[class^="banner-cta"]');
     main.append(responseEl);
-
+    const header = document.querySelector('header');
+    header.addEventListener('gnav.init', () => {
+      const gnavCta = header.querySelector('.gnav-cta a');
+      if (gnavCta) {
+        bannerCTABlock.querySelector('a').href = gnavCta.href;
+      }
+    });
     // decorate the banner block
     decorateBlock(bannerCTABlock);
     loadBlock(bannerCTABlock);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1217,7 +1217,7 @@ async function loadfooterBanner(main) {
     const bannerCTABlock = responseEl.querySelector('div[class^="banner-cta"]');
     main.append(responseEl);
     const header = document.querySelector('header');
-    header.addEventListener('gnav.init', () => {
+    header.addEventListener('gnav:init', () => {
       const gnavCta = header.querySelector('.gnav-cta a');
       if (gnavCta) {
         bannerCTABlock.querySelector('a').href = gnavCta.href;


### PR DESCRIPTION
…cta href if it is existed.

Jira ticket: [MWPW-106285](https://jira.corp.adobe.com/browse/MWPW-106285)
Testing URL:
Main: https://main--business-website--adobe.hlx3.page/drafts/cmillar/gnav/
This change: https://gnav-banner-match--business-website--adobe.hlx3.page/drafts/cmillar/gnav/

You should see the footer banner CTA's URL is matching with Gnav's one.

<img width="926" alt="Screen Shot 2022-03-30 at 5 38 29 PM" src="https://user-images.githubusercontent.com/55804872/160948238-83e6d4ab-6533-4e15-80b6-0cc4e739d57d.png">

I also created a PR for `adobecom/gnav`: https://github.com/adobecom/gnav/pull/9.