### PR TITLE
Fixing issue with tags doesn't load from taxonomy when it loads too f…

### DIFF
--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -1,5 +1,6 @@
 import {
   toClassName,
+  loadTaxonomy,
 } from '../../scripts/scripts.js';
 
 export default function decorateTags(blockEl) {
@@ -20,4 +21,6 @@ export default function decorateTags(blockEl) {
     a.classList.add('button');
     container.append(a);
   });
+  const taxElements = document.querySelectorAll('.tags a');
+  loadTaxonomy(taxElements);
 }


### PR DESCRIPTION
…ast (with cache), and small bugs

Merging this will resolve: [MWPW-110382](https://jira.corp.adobe.com/browse/MWPW-110382)

Current: 
https://main--business-website--adobe.hlx.page/kr/blog/the-latest/2022-adobe-digital-trends-report

Reproduce steps:
1. Go to the current url above
2. Reload with empty cache and hard reload
<img width="375" alt="image" src="https://user-images.githubusercontent.com/55804872/169623534-c9ff11c0-7c16-4142-953b-cc05d6834b44.png">
3. Check the tags links at the bottom of page.
4. Reload again without clearing cache, and check again.
Either step 3 & 4 or just 4 will shows the issue that tag links having 404 due to it doesn't load taxonomy so they look like `.../tags/`

Fixed:
https://tags-fix--business-website--adobe.hlx.page/kr/blog/the-latest/2022-adobe-digital-trends-report

With above link, it should always have correct links.