### PR TITLE
trying to fix recommended article

### DIFF
--- a/blocks/recommended-articles/recommended-articles.js
+++ b/blocks/recommended-articles/recommended-articles.js
@@ -38,6 +38,17 @@ async function decorateRecommendedArticles(recommendedArticlesEl, paths) {
 export default async function decorate(blockEl) {
   const anchors = [...blockEl.querySelectorAll('a')];
   blockEl.innerHTML = '';
-  const paths = anchors.map((a) => new URL(a.href).pathname);
+  const urls = anchors.map((a) => new URL(a.href));
+  const paths = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const url of urls) {
+    if (url.host === 'blog.adobe.com') {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await fetch(url.href);
+      paths.push(new URL(res.url).pathname);
+    } else {
+      paths.push(url.pathname);
+    }
+  }
   await decorateRecommendedArticles(blockEl, paths);
 }


### PR DESCRIPTION
This is provide the workaround and will render the recommended articles.
And won't hurt the site speed as I tested.
<img width="1683" alt="image" src="https://user-images.githubusercontent.com/55804872/170145569-4050f267-adf6-400b-9c6a-a67a8963062d.png">
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/55804872/170145585-df508d1f-ebeb-4f79-8118-39b2cb38db3e.png">

*You may need the CORS extension to see the right result in test URL but it should be fine when it is shipped to production.

Current:
https://main--business-website--adobe.hlx.page/kr/blog/the-latest/2022-adobe-digital-trends-report

Test:
https://recommended-article-fix--business-website--adobe.hlx.page/kr/blog/the-latest/2022-adobe-digital-trends-report