### PR TITLE
Exclude fpost folder from query-index, add index/sitemap for fpost specifically 

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -13,6 +13,7 @@ indices:
       - '**/blog/banners/**'
       - '**/blog/categories/**'
       - '**/blog/tags/**'
+      - '**/blog/fpost/**'
     target: /blog/query-index.xlsx
     properties:
       author:
@@ -127,3 +128,18 @@ indices:
     include:
       - /kr/blog/**
     target: /kr/blog/query-index.xlsx
+
+  fpost:
+    <<: *default
+    exclude: 
+      - '/blog/**'  
+      - '**/blog/index*'
+      - '**/blog/gnav*'
+      - '**/blog/footer*'
+      - '**/blog/authors/**'
+      - '**/blog/banners/**'
+      - '**/blog/categories/**'
+      - '**/blog/tags/**'    
+    include:
+      - /blog/fpost/**
+    target: /blog/fpost/query-index.xlsx

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -40,3 +40,9 @@ sitemaps:
         destination: /blog/sitemap-kr.xml
         hreflang: ko
         alternate: /kr/{path}
+      fpost:
+        source: /blog/fpost/query-index.json
+        destination: /blog/fpost/sitemap-fpost.xml
+        hreflang: en
+        alternate: /en/{path}
+


### PR DESCRIPTION


## How Has This Been Tested?
This can only be tested on prod. 

Once merged, and an item is published, sitemap should populate and query-index be generated. query index will need sitemap tab. 

https://main--business-website--adobe.hlx.page/blog/fpost/sitemap.xml 
https://main--business-website--adobe.hlx.page/blog/fpost/query-index.json 

