### PR TITLE
Support h1 to be the title of article cards.

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -23,6 +23,10 @@ indices:
         select: head > meta[property="og:title"]
         value: |
           attribute(el, 'content')
+      h1:
+        select: h1
+        value: |
+          attribute(el, 'content')
       date:
         select: head > meta[name="publication-date"]
         value: |


### PR DESCRIPTION
Resolving issue: [MWPW-114484](https://jira.corp.adobe.com/browse/MWPW-114484)

Testing
Before: https://main--business-website--adobe.hlx.page/drafts/seanchoi/recommended-articles-testing-page
After: https://h1-title-card--business-website--adobe.hlx.page/drafts/seanchoi/recommended-articles-testing-page

QA Note, for feeds page such as https://h1-title-card--business-website--adobe.hlx.page/blog/tags/basics won't work until this get merged since they use query-index.xlsx. I am just hoping https://github.com/adobe/business-website/pull/233/files#diff-2fde5d2508ed34a1f6ec8ec4ce8133096d591a7d5901c702a0e2e558589f7265R26-R29 would work for this because I haven't found a good way to test..