### PR TITLE
MWPW-122481: URL fix for banner images

### DIFF
--- a/blog/blocks/banner/banner.js
+++ b/blog/blocks/banner/banner.js
@@ -31,7 +31,7 @@ export default function decorate(block) {
         const picture = responseEl.querySelector('picture');
         const source = picture.querySelector('source');
         const img = picture.querySelector('img');
-        source.srcset = origin + source.srcset.slice(1);
+        source.srcset = origin + new URL(img.src).pathname;
         img.src = origin + new URL(img.src).pathname;
         bannerImage.append(picture);
 


### PR DESCRIPTION
Fixes first element of `<picture>` element broken in any banner promotion block. 
[MWPW-122481](https://jira.corp.adobe.com/browse/MWPW-122481)
Before: (near footer)
https://business.adobe.com/jp/blog/the-latest/dx-2022-webinar-pharmaceutical-202209

After:  (near footer)
https://bugfix-banner-images--business-website--adobe.hlx.page/jp/blog/the-latest/dx-2022-webinar-pharmaceutical-202209