### PR TITLE
Update RUM, and prevent endless loops

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -545,6 +545,18 @@ export function initHlx() {
       console.log(e);
     }
   }
+
+  sampleRUM('top');
+
+  window.addEventListener('load', () => sampleRUM('load'));
+
+  window.addEventListener('unhandledrejection', (event) => {
+    sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
+  });
+
+  window.addEventListener('error', (event) => {
+    sampleRUM('error', { source: event.filename, target: event.lineno });
+  });
 }
 
 initHlx();
@@ -576,20 +588,6 @@ const alloy = true;
 
 const LCP_BLOCKS = ['featured-article', 'article-header'];
 window.RUM_GENERATION = 'biz-gen4'; // add your RUM generation information here
-
-const olderror = window.onerror;
-window.onerror = (event, source, line) => {
-  sampleRUM('error', { source, target: line });
-  // keep the old error handler around
-  if (typeof olderror === 'function') {
-    olderror(event, source, line);
-  } else {
-    throw new Error(event);
-  }
-};
-
-sampleRUM('top');
-window.addEventListener('load', () => sampleRUM('load'));
 
 loadPage(document);
 

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -44,10 +44,10 @@ export function sampleRUM(checkpoint, data = {}) {
       const random = Math.random();
       const isSelected = (random * weight < 1);
       // eslint-disable-next-line object-curly-newline
-      window.hlx.rum = { weight, id, random, isSelected, sampleRUM };
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM, pings: 0 };
     }
     const { weight, id } = window.hlx.rum;
-    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected && window.hlx.MAX_RUM_PINGS > window.hlx.rum.pings++) {
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
         const body = JSON.stringify({ weight, id, referer: window.location.href, generation: window.hlx.RUM_GENERATION, checkpoint, ...data });
@@ -587,7 +587,8 @@ const usp = new URLSearchParams(window.location.search);
 const alloy = true;
 
 const LCP_BLOCKS = ['featured-article', 'article-header'];
-window.RUM_GENERATION = 'biz-gen4'; // add your RUM generation information here
+window.hlx.RUM_GENERATION = 'biz-gen4'; // add your RUM generation information here
+window.hlx.MAX_RUM_PINGS = 50;
 
 loadPage(document);
 

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -18,6 +18,21 @@ const PRODUCTION_DOMAINS = ['business.adobe.com'];
  * @param {Object} data additional data for RUM sample
  */
 export function sampleRUM(checkpoint, data = {}) {
+  sampleRUM.defer = sampleRUM.defer || [];
+  const defer = (fnname) => {
+    sampleRUM[fnname] = sampleRUM[fnname]
+      || ((...args) => sampleRUM.defer.push({ fnname, args }));
+  };
+  sampleRUM.drain = sampleRUM.drain
+    || ((dfnname, fn) => {
+      sampleRUM[dfnname] = fn;
+      sampleRUM.defer
+        .filter(({ fnname }) => dfnname === fnname)
+        .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
+    });
+  sampleRUM.on = (chkpnt, fn) => { sampleRUM.cases[chkpnt] = fn; };
+  defer('observe');
+  defer('cwv');
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
@@ -29,39 +44,33 @@ export function sampleRUM(checkpoint, data = {}) {
       const random = Math.random();
       const isSelected = (random * weight < 1);
       // eslint-disable-next-line object-curly-newline
-      window.hlx.rum = { weight, id, random, isSelected };
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM };
     }
-    const { random, weight, id } = window.hlx.rum;
-    if (random && (random * weight < 1)) {
-      const sendPing = () => {
+    const { weight, id } = window.hlx.rum;
+    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+      const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
-        const body = JSON.stringify({ weight, id, referer: window.location.href, generation: window.RUM_GENERATION, checkpoint, ...data });
+        const body = JSON.stringify({ weight, id, referer: window.location.href, generation: window.hlx.RUM_GENERATION, checkpoint, ...data });
         const url = `https://rum.hlx.page/.rum/${weight}`;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
+        // eslint-disable-next-line no-console
+        console.debug(`ping:${checkpoint}`, pdata);
       };
-      sendPing();
-      // special case CWV
-      if (checkpoint === 'cwv') {
-        // use classic script to avoid CORS issues
-        const script = document.createElement('script');
-        script.src = 'https://rum.hlx.page/.rum/web-vitals/dist/web-vitals.iife.js';
-        script.onload = () => {
-          const storeCWV = (measurement) => {
-            data.cwv = {};
-            data.cwv[measurement.name] = measurement.value;
-            sendPing();
-          };
-            // When loading `web-vitals` using a classic script, all the public
-            // methods can be found on the `webVitals` global namespace.
-          window.webVitals.getCLS(storeCWV);
-          window.webVitals.getFID(storeCWV);
-          window.webVitals.getLCP(storeCWV);
-        };
-        document.head.appendChild(script);
-      }
+      sampleRUM.cases = sampleRUM.cases || {
+        cwv: () => sampleRUM.cwv(data) || true,
+        lazy: () => {
+          // use classic script to avoid CORS issues
+          const script = document.createElement('script');
+          script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
+          document.head.appendChild(script);
+          return true;
+        },
+      };
+      sendPing(data);
+      if (sampleRUM.cases[checkpoint]) { sampleRUM.cases[checkpoint](); }
     }
-  } catch (e) {
+  } catch (error) {
     // something went wrong
   }
 }
@@ -566,7 +575,7 @@ const usp = new URLSearchParams(window.location.search);
 const alloy = true;
 
 const LCP_BLOCKS = ['featured-article', 'article-header'];
-window.RUM_GENERATION = 'biz-gen3'; // add your RUM generation information here
+window.RUM_GENERATION = 'biz-gen4'; // add your RUM generation information here
 sampleRUM.mediaobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -47,6 +47,7 @@ export function sampleRUM(checkpoint, data = {}) {
       window.hlx.rum = { weight, id, random, isSelected, sampleRUM, pings: 0 };
     }
     const { weight, id } = window.hlx.rum;
+    // eslint-disable-next-line max-len, no-plusplus
     if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected && window.hlx.MAX_RUM_PINGS > window.hlx.rum.pings++) {
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -576,71 +576,6 @@ const alloy = true;
 
 const LCP_BLOCKS = ['featured-article', 'article-header'];
 window.RUM_GENERATION = 'biz-gen4'; // add your RUM generation information here
-sampleRUM.mediaobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
-  entries
-    .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => {
-      sampleRUM.mediaobserver.unobserve(entry.target); // observe only once
-      const target = sampleRUM.targetselector(entry.target);
-      const source = sampleRUM.sourceselector(entry.target);
-      sampleRUM('viewmedia', { target, source });
-    });
-}, { threshold: 0.25 }) : { observe: () => {} };
-
-sampleRUM.blockobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
-  entries
-    .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => {
-      sampleRUM.blockobserver.unobserve(entry.target); // observe only once
-      const target = sampleRUM.targetselector(entry.target);
-      const source = sampleRUM.sourceselector(entry.target);
-      sampleRUM('viewblock', { target, source });
-    });
-}, { threshold: 0.25 }) : { observe: () => {} };
-
-sampleRUM.observe = ((elements) => {
-  elements.forEach((element) => {
-    if (element.tagName.toLowerCase() === 'img'
-    || element.tagName.toLowerCase() === 'video'
-    || element.tagName.toLowerCase() === 'audio'
-    || element.tagName.toLowerCase() === 'iframe') {
-      sampleRUM.mediaobserver.observe(element);
-    } else {
-      sampleRUM.blockobserver.observe(element);
-    }
-  });
-});
-
-sampleRUM.sourceselector = (element) => {
-  if (element === document.body || element === document.documentElement || !element) {
-    return undefined;
-  }
-  if (element.id) {
-    return `#${element.id}`;
-  }
-  if (element.getAttribute('data-block-name')) {
-    return `.${element.getAttribute('data-block-name')}`;
-  }
-  return sampleRUM.sourceselector(element.parentElement);
-};
-
-sampleRUM.targetselector = (element) => {
-  let value = element.getAttribute('href') || element.currentSrc || element.getAttribute('src');
-  if (value && value.startsWith('https://')) {
-    // resolve relative links
-    value = new URL(value, window.location).href;
-  }
-  return value;
-};
-
-sampleRUM('top');
-window.addEventListener('load', () => sampleRUM('load'));
-document.addEventListener('click', (event) => {
-  sampleRUM('click', {
-    target: sampleRUM.targetselector(event.target),
-    source: sampleRUM.sourceselector(event.target),
-  });
-});
 
 const olderror = window.onerror;
 window.onerror = (event, source, line) => {
@@ -655,7 +590,6 @@ window.onerror = (event, source, line) => {
 
 sampleRUM('top');
 window.addEventListener('load', () => sampleRUM('load'));
-document.addEventListener('click', () => sampleRUM('click'));
 
 loadPage(document);
 


### PR DESCRIPTION
There are two parts to this PR:

### Re-align RUM code with current boilerplate

- feat(rum): align sampleRUM with helix-boileplate
- fix(rum): remove code that is already included in enhanced-rum
- refactor(rum): move rum init into initHlx

### Limit the number of pings that can be made from RUM

- feat(rum): add limit to the number of rum pings to be made (https://github.com/adobe/business-website/pull/241/commits/1f72fe511fb7d7ab7874485662fe90de2709077e)

This should prevent the endless `error` ping of doom that we sometimes see in the logs,
but there is a good chance that we'll never see this again because the refactoring
made the `onerror` tracking more robust

Test: https://rum-stop--business-website--adobe.hlx.page/blog/?rum=on

Click 50 times and see how the RUM collection stops after a while.
